### PR TITLE
[FEAT] 여행 리포트 조회 API (#72)

### DIFF
--- a/trippy-server/src/main/java/org/scoula/common/exception/enums/SuccessCode.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/enums/SuccessCode.java
@@ -49,6 +49,7 @@ public enum SuccessCode {
 
 	//여행로그
 	FIND_TRAVEL_LOG_SUCCESS(HttpStatus.OK, "여행 로그 조회 성공"),
+	FIND_TRAVEL_REPORT_SUCCESS(HttpStatus.OK, "여행 리포트 조회 성공"),
 
 	FIND_ACCOUNTS_LIST_SUCCESS(HttpStatus.OK, "계좌 목록 조회 성공"),
 

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/TravelLogController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/TravelLogController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 
-@Api(tags = "Travel Log")
+@Api(tags = "Travel")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/travel-log")

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
@@ -1,4 +1,35 @@
 package org.scoula.controller.travel.report;
 
+import lombok.RequiredArgsConstructor;
+import org.scoula.common.dto.SuccessResponse;
+import org.scoula.common.exception.enums.SuccessCode;
+import org.scoula.controller.travel.report.dto.res.TravelReportDTO;
+import org.scoula.service.travel.TravelReportService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+import io.swagger.annotations.*;
+
+@Api(tags = "Travel")
+@RestController
+@RequestMapping("/travel-report")
+@RequiredArgsConstructor
 public class TravelReportController {
+    private final TravelReportService travelReportService;
+
+    @ApiOperation(value = "[JWT] 여행 리포트 조회", notes = "여행 ID로 소비 리포트를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "여행 소비 리포트 조회 성공"),
+            @ApiResponse(code = 404, message = "해당 여행이 존재하지 않습니다.")
+    })
+    @GetMapping("/{travelId}/travel-report")
+    public SuccessResponse<TravelReportDTO> getTravelReport(
+            @ApiParam(value = "여행 ID", required = true, example = "5")
+            @PathVariable Long travelId
+    ) {
+        return SuccessResponse.success(SuccessCode.FIND_TRAVEL_REPORT_SUCCESS, travelReportService.getTravelReport(travelId));
+    }
 }

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
@@ -1,0 +1,4 @@
+package org.scoula.controller.travel.report;
+
+public class TravelReportController {
+}

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/res/TravelReportDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/res/TravelReportDTO.java
@@ -1,0 +1,35 @@
+package org.scoula.controller.travel.report.dto.res;
+
+import org.scoula.domain.travel.TravelReportVO;
+
+public record TravelReportDTO(
+        Long travelId,
+        String destination,
+        String travelBeginDate,
+        String travelEndDate,
+        Integer totalExpense,
+        Integer totalFood,
+        Integer totalActivity,
+        Integer totalAcc,
+        Integer totalTransport,
+        Integer totalShop,
+        String maxSpendingTitle,
+        Long maxSpendingAmount
+) {
+    public static TravelReportDTO from(TravelReportVO vo) {
+        return new TravelReportDTO(
+                vo.getTravelId(),
+                vo.getDestination(),
+                vo.getTravelBeginDate(),
+                vo.getTravelEndDate(),
+                vo.getTotalExpense(),
+                vo.getTotalFood(),
+                vo.getTotalActivity(),
+                vo.getTotalAcc(),
+                vo.getTotalTransport(),
+                vo.getTotalShop(),
+                vo.getMaxSpendingTitle(),
+                vo.getMaxSpendingAmount()
+        );
+    }
+}

--- a/trippy-server/src/main/java/org/scoula/domain/travel/TravelReportVO.java
+++ b/trippy-server/src/main/java/org/scoula/domain/travel/TravelReportVO.java
@@ -26,4 +26,6 @@ public class TravelReportVO extends BaseTime {
 	private Integer totalAcc;
 	private Integer totalTransport;
 	private Integer totalShop;
+	private String maxSpendingTitle;
+	private Long maxSpendingAmount;
 }

--- a/trippy-server/src/main/java/org/scoula/domain/travel/TravelReportVO.java
+++ b/trippy-server/src/main/java/org/scoula/domain/travel/TravelReportVO.java
@@ -9,6 +9,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Data
 @Getter
 @NoArgsConstructor
@@ -16,16 +18,25 @@ import lombok.NoArgsConstructor;
 @Builder
 @EqualsAndHashCode(callSuper = true)
 public class TravelReportVO extends BaseTime {
-	private String accountId;
-	private Long userId;
 	private Long settlementId;
 	private Long travelId;
+	private Long userId;
+	private String accountId;
+
+	private String destination;
+	private String travelBeginDate;
+	private String travelEndDate;
+
 	private Integer totalExpense;
 	private Integer totalFood;
 	private Integer totalActivity;
 	private Integer totalAcc;
 	private Integer totalTransport;
 	private Integer totalShop;
+
 	private String maxSpendingTitle;
 	private Long maxSpendingAmount;
+
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
 }

--- a/trippy-server/src/main/java/org/scoula/mapper/travel/TravelReportMapper.java
+++ b/trippy-server/src/main/java/org/scoula/mapper/travel/TravelReportMapper.java
@@ -1,7 +1,11 @@
 package org.scoula.mapper.travel;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.scoula.domain.travel.TravelReportVO;
+
+import java.util.List;
 
 @Mapper
 public interface TravelReportMapper {
+    TravelReportVO getTravelReport(Long travelId);
 }

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
@@ -1,0 +1,16 @@
+package org.scoula.service.travel;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.controller.travel.report.dto.res.TravelReportDTO;
+import org.scoula.mapper.travel.TravelReportMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TravelReportService {
+    private final TravelReportMapper travelReportMapper;
+
+    public TravelReportDTO getTravelReport(final Long travelId) {
+        return TravelReportDTO.from(travelReportMapper.getTravelReport(travelId));
+    }
+}

--- a/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelReportMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelReportMapper.xml
@@ -19,4 +19,35 @@
         <result property="createdAt" column="created_at"/>
         <result property="updatedAt" column="updated_at"/>
     </resultMap>
+
+    <select id="getTravelReport" resultType="org.scoula.domain.travel.TravelReportVO">
+        SELECT
+            tr.settlement_id AS settlementId,
+            tr.account_id AS accountId,
+            tr.user_id AS userId,
+            tl.travel_id AS travelId,
+            tl.destination,
+            DATE_FORMAT(tl.travel_begin_date, '%Y-%m-%d') AS travelBeginDate,
+            DATE_FORMAT(tl.travel_end_date, '%Y-%m-%d') AS travelEndDate,
+            tr.total_expense AS totalExpense,
+            tr.total_food AS totalFood,
+            tr.total_activity AS totalActivity,
+            tr.total_acc AS totalAcc,
+            tr.total_transport AS totalTransport,
+            tr.total_shop AS totalShop,
+            tx.title AS maxSpendingTitle,
+            tx.amount AS maxSpendingAmount
+        FROM travel_log tl
+                 JOIN travel_report tr ON tl.travel_id = tr.travel_id
+                 LEFT JOIN (
+            SELECT t.account_id, t.title, t.amount, t.created_at
+            FROM transaction t
+            WHERE t.transaction_type = '지출'
+            ORDER BY t.amount DESC
+                LIMIT 1
+        ) tx
+                           ON tx.account_id = tr.account_id
+                               AND tx.created_at BETWEEN tl.travel_begin_date AND tl.travel_end_date
+        WHERE tl.travel_id = #{travelId}
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #72

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
2H/4H

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
travel_report 테이블에서 선택한 travel_id에 해당하는 데이터를 가져오고,
해당 여행 기간 중 가장 큰 소비를 찾기 위해 travel_log에서 여행 기간(travelBeginDate, travelEndDate)을 가지고 transaction테이블에서 travel_report의 account_id가 동일한 데이터들 중 여행 기간 내에 발생한 거래 내역을 필터링하고
그 중 거래 금액이 가장 큰 항목을 조회하여 프론트로 보냅니다...


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
<img width="350" height="250" alt="image" src="https://github.com/user-attachments/assets/66772123-65a5-4eec-9cb6-53f6e0aca52a" />

