### PR TITLE
[FEAT] 여행 리포트 생성 API #74

### DIFF
--- a/trippy-server/src/main/java/org/scoula/common/exception/enums/ErrorCode.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/enums/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
 	NOT_GROUP_ACCOUNT_LEADER_EXCEPTION(HttpStatus.BAD_REQUEST, "모임계좌 모임주가 아닌 사용자입니다."),
 	INVALID_RESIDENT_NUMBER_EXCEPTION(HttpStatus.BAD_REQUEST, "주민번호가 잘못되었습니다."),
 	INVALID_PASSWORD_EXCEPTION(HttpStatus.BAD_REQUEST, "비밀번호가 잘못되었습니다."),
+	TRAVEL_ID_REQUIRED(HttpStatus.BAD_REQUEST, "travelId는 필수입니다."),
+	TRAVEL_LOG_ACCOUNT_ID_EMPTY(HttpStatus.BAD_REQUEST, "travel_log.account_id가 비어 있습니다. travelId={0}"),
 
 	//401 UNAUTHORIZED _인증
 	TOKEN_NOT_CONTAINED_EXCEPTION(HttpStatus.UNAUTHORIZED, "Access Token이 필요합니다."),
@@ -37,7 +39,7 @@ public enum ErrorCode {
 	EXCHANGE_RATE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "환율 API 호출 중 오류 발생했습니다."),
 	AIR_TICKET_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 항공권Id가 존재하지 않습니다."),
 	ACCOMMODATION_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 숙소가 존재하지 않습니다."), //관광 바우처 이미지가 잘못되었습니다
-
+	TRAVEL_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 travelId가 존재하지 않습니다. travelId={0}"),
 
 	//405 METHOD_NOT_ALLOWED
 

--- a/trippy-server/src/main/java/org/scoula/common/exception/enums/SuccessCode.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/enums/SuccessCode.java
@@ -63,6 +63,7 @@ public enum SuccessCode {
 	//여행로그
 	FIND_TRAVEL_LOG_SUCCESS(HttpStatus.OK, "여행 로그 조회 성공"),
 	FIND_TRAVEL_REPORT_SUCCESS(HttpStatus.OK, "여행 리포트 조회 성공"),
+	CREATE_TRAVEL_REPORT_SUCCESS(HttpStatus.OK, "여행 리포트 생성 성공"),
 	CREATE_TRAVEL_LOG_SUCCESS(HttpStatus.OK, "여행 로그 생성 성공");
 
 	private final HttpStatus httpStatus;

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/TravelLogController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/TravelLogController.java
@@ -51,7 +51,7 @@ public class TravelLogController {
 	@PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
 	public SuccessNonDataResponse createTravelLog(
 		@ApiParam(value = "유저 ID", required = true, example = "101")
-		@RequestParam Long userId,
+		@RequestHeader("userId") Long userId,
 
 		@ApiParam(value = "여행 이미지 파일")
 		@RequestPart(value = "travelImg", required = false)

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/req/TravelLogCreateDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/req/TravelLogCreateDTO.java
@@ -1,17 +1,54 @@
 package org.scoula.controller.travel.log.dto.req;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 
+import javax.validation.constraints.*;
 import java.time.LocalDateTime;
 
 @Builder
+@ApiModel(description = "Travel Log 생성 요청 DTO")
 public record TravelLogCreateDTO (
+        @ApiModelProperty(value = "사용자 ID", required = true, example = "101")
+        @NotNull(message = "userId는 필수입니다.")
         Long userId,
+
+        @ApiModelProperty(value = "연결된 계좌 ID", required = true, example = "acct_20250729_001")
+        @NotBlank(message = "accountId는 필수입니다.")
+        @Size(max = 50, message = "accountId는 최대 50자입니다.")
         String accountId,
+
+        @ApiModelProperty(value = "여행 제목", required = true, example = "오사카 3박 4일 먹투어")
+        @NotBlank(message = "title은 필수입니다.")
+        @Size(max = 100, message = "title은 최대 100자입니다.")
         String title,
+
+        @ApiModelProperty(value = "여행 시작일시 (ISO-8601)", required = true, example = "2025-07-10T09:00:00")
+        @NotNull(message = "travelBeginDate는 필수입니다.")
         LocalDateTime travelBeginDate,
+
+        @ApiModelProperty(value = "여행 종료일시 (ISO-8601)", required = true, example = "2025-07-13T18:00:00")
+        @NotNull(message = "travelEndDate는 필수입니다.")
         LocalDateTime travelEndDate,
+
+        @ApiModelProperty(value = "여행지(도시/지역명)", required = true, example = "오사카, 일본")
+        @NotBlank(message = "destination은 필수입니다.")
+        @Size(max = 50, message = "destination은 최대 50자입니다.")
         String destination,
+
+        @ApiModelProperty(value = "AI 생성 로그 여부", example = "false")
         Boolean isGenerated,
+
+        @ApiModelProperty(value = "대표 이미지 URL", example = "https://example.com/travel/abc.jpg")
+        @Size(max = 255, message = "travelImg URL은 최대 255자입니다.")
+        @Pattern(regexp = "^https?://.+", message = "travelImg는 http(s) URL이어야 합니다.")
         String travelImg
-) {}
+) {
+    // 교차 필드 검증: 종료일이 시작일 이전이면 안 됨
+    @AssertTrue(message = "travelEndDate는 travelBeginDate 이후여야 합니다.")
+    public boolean isEndAfterBegin() {
+        if (travelBeginDate == null || travelEndDate == null) return true; // 다른 @NotNull이 처리
+        return !travelEndDate.isBefore(travelBeginDate);
+    }
+}

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/req/TravelLogCreateDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/req/TravelLogCreateDTO.java
@@ -10,9 +10,6 @@ import java.time.LocalDateTime;
 @Builder
 @ApiModel(description = "Travel Log 생성 요청 DTO")
 public record TravelLogCreateDTO (
-        @ApiModelProperty(value = "사용자 ID", required = true, example = "101")
-        @NotNull(message = "userId는 필수입니다.")
-        Long userId,
 
         @ApiModelProperty(value = "연결된 계좌 ID", required = true, example = "acct_20250729_001")
         @NotBlank(message = "accountId는 필수입니다.")

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/req/TravelLogCreateDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/req/TravelLogCreateDTO.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 @Builder
 public record TravelLogCreateDTO (
         Long userId,
+        String accountId,
         String title,
         LocalDateTime travelBeginDate,
         LocalDateTime travelEndDate,

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/res/TravelLogDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/res/TravelLogDTO.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 public record TravelLogDTO(
         Long travelId,
         Long userId,
+        String accountId,
         String title,
         LocalDateTime travelBeginDate,
         LocalDateTime travelEndDate,

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/res/TravelLogDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/res/TravelLogDTO.java
@@ -11,5 +11,5 @@ public record TravelLogDTO(
         String destination,
         Boolean isGenerated,
         String travelImg,
-        Integer memberCount
+        Long memberCount
 ) {}

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
@@ -33,16 +33,16 @@ public class TravelReportController {
 
 
 
-    @ApiOperation(value = "[JWT] 여행 리포트 생성", notes = "travel_log의 account_id와 기간을 사용해 집계하고 저장합니다.")
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "여행 소비 리포트 저장 성공")
-    })
-    @PostMapping
-    public SuccessResponse<String> createTravelReport(@RequestBody TravelReportCreateRequestDTO request) {
-        long settlementId = travelReportService.createTravelReport(request);
-        return SuccessResponse.success(
-                SuccessCode.CREATE_TRAVEL_REPORT_SUCCESS,
-                "travel_report 저장 완료 (settlementId=" + settlementId + ")"
-        );
-    }
+//    @ApiOperation(value = "[JWT] 여행 리포트 생성", notes = "travel_log의 account_id와 기간을 사용해 집계하고 저장합니다.")
+//    @ApiResponses({
+//            @ApiResponse(code = 200, message = "여행 소비 리포트 저장 성공")
+//    })
+//    @PostMapping
+//    public SuccessResponse<String> createTravelReport(@RequestBody TravelReportRequestDTO request) {
+//        long settlementId = travelReportService.createTravelReport(request);
+//        return SuccessResponse.success(
+//                SuccessCode.CREATE_TRAVEL_REPORT_SUCCESS,
+//                "travel_report 저장 완료 (settlementId=" + settlementId + ")"
+//        );
+//    }
 }

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
@@ -1,7 +1,7 @@
 package org.scoula.controller.travel.report;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.scoula.common.dto.SuccessNonDataResponse;
 import org.scoula.common.dto.SuccessResponse;
 import org.scoula.common.exception.enums.SuccessCode;
 import org.scoula.controller.travel.report.dto.req.TravelReportRequestDTO;
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.*;
 
 import io.swagger.annotations.*;
 
-@Slf4j
 @Api(tags = "Travel")
 @RestController
 @RequestMapping("/travel-report")
@@ -37,11 +36,11 @@ public class TravelReportController {
 
     @ApiOperation(value = "[JWT] 여행 리포트 생성", notes = "travel_log의 account_id와 기간을 사용해 집계하고 저장합니다.")
     @ApiResponses({
-            @ApiResponse(code = 200, message = "여행 소비 리포트 저장 성공")
+    @ApiResponse(code = 200, message = "여행 소비 리포트 저장 성공")
     })
     @PostMapping
-    public SuccessResponse<String> createTravelReport(@RequestBody TravelReportRequestDTO request) {
+    public SuccessNonDataResponse createTravelReport(@RequestBody TravelReportRequestDTO request) {
         travelReportService.createTravelReport(request);
-        return SuccessResponse.success(SuccessCode.CREATE_TRAVEL_REPORT_SUCCESS, "travel_report 저장 완료");
+        return SuccessNonDataResponse.success(SuccessCode.CREATE_TRAVEL_REPORT_SUCCESS);
     }
 }

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
@@ -41,7 +41,6 @@ public class TravelReportController {
     })
     @PostMapping
     public SuccessResponse<String> createTravelReport(@RequestBody TravelReportRequestDTO request) {
-        log.info("[TR] controller POST /travel-report body={}", request);
         travelReportService.createTravelReport(request);
         return SuccessResponse.success(SuccessCode.CREATE_TRAVEL_REPORT_SUCCESS, "travel_report 저장 완료");
     }

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
@@ -3,12 +3,10 @@ package org.scoula.controller.travel.report;
 import lombok.RequiredArgsConstructor;
 import org.scoula.common.dto.SuccessResponse;
 import org.scoula.common.exception.enums.SuccessCode;
+import org.scoula.controller.travel.report.dto.req.TravelReportRequestDTO;
 import org.scoula.controller.travel.report.dto.res.TravelReportDTO;
 import org.scoula.service.travel.TravelReportService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 import io.swagger.annotations.*;
@@ -25,11 +23,26 @@ public class TravelReportController {
             @ApiResponse(code = 200, message = "여행 소비 리포트 조회 성공"),
             @ApiResponse(code = 404, message = "해당 여행이 존재하지 않습니다.")
     })
-    @GetMapping("/{travelId}/travel-report")
+    @GetMapping("/{travelId}")
     public SuccessResponse<TravelReportDTO> getTravelReport(
             @ApiParam(value = "여행 ID", required = true, example = "5")
             @PathVariable Long travelId
     ) {
         return SuccessResponse.success(SuccessCode.FIND_TRAVEL_REPORT_SUCCESS, travelReportService.getTravelReport(travelId));
+    }
+
+
+
+    @ApiOperation(value = "[JWT] 여행 리포트 생성", notes = "travel_log의 account_id와 기간을 사용해 집계하고 저장합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "여행 소비 리포트 저장 성공")
+    })
+    @PostMapping
+    public SuccessResponse<String> createTravelReport(@RequestBody TravelReportCreateRequestDTO request) {
+        long settlementId = travelReportService.createTravelReport(request);
+        return SuccessResponse.success(
+                SuccessCode.CREATE_TRAVEL_REPORT_SUCCESS,
+                "travel_report 저장 완료 (settlementId=" + settlementId + ")"
+        );
     }
 }

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/TravelReportController.java
@@ -1,6 +1,7 @@
 package org.scoula.controller.travel.report;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.scoula.common.dto.SuccessResponse;
 import org.scoula.common.exception.enums.SuccessCode;
 import org.scoula.controller.travel.report.dto.req.TravelReportRequestDTO;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 import io.swagger.annotations.*;
 
+@Slf4j
 @Api(tags = "Travel")
 @RestController
 @RequestMapping("/travel-report")
@@ -33,16 +35,14 @@ public class TravelReportController {
 
 
 
-//    @ApiOperation(value = "[JWT] 여행 리포트 생성", notes = "travel_log의 account_id와 기간을 사용해 집계하고 저장합니다.")
-//    @ApiResponses({
-//            @ApiResponse(code = 200, message = "여행 소비 리포트 저장 성공")
-//    })
-//    @PostMapping
-//    public SuccessResponse<String> createTravelReport(@RequestBody TravelReportRequestDTO request) {
-//        long settlementId = travelReportService.createTravelReport(request);
-//        return SuccessResponse.success(
-//                SuccessCode.CREATE_TRAVEL_REPORT_SUCCESS,
-//                "travel_report 저장 완료 (settlementId=" + settlementId + ")"
-//        );
-//    }
+    @ApiOperation(value = "[JWT] 여행 리포트 생성", notes = "travel_log의 account_id와 기간을 사용해 집계하고 저장합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "여행 소비 리포트 저장 성공")
+    })
+    @PostMapping
+    public SuccessResponse<String> createTravelReport(@RequestBody TravelReportRequestDTO request) {
+        log.info("[TR] controller POST /travel-report body={}", request);
+        travelReportService.createTravelReport(request);
+        return SuccessResponse.success(SuccessCode.CREATE_TRAVEL_REPORT_SUCCESS, "travel_report 저장 완료");
+    }
 }

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/req/ExpenseSummaryParam.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/req/ExpenseSummaryParam.java
@@ -1,0 +1,11 @@
+package org.scoula.controller.travel.report.dto.req;
+
+import java.time.LocalDateTime;
+
+public record ExpenseSummaryParam(
+        String accountId,
+        Long userId,
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime
+) {
+}

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/req/TravelReportInsertParam.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/req/TravelReportInsertParam.java
@@ -1,0 +1,14 @@
+package org.scoula.controller.travel.report.dto.req;
+
+public record TravelReportInsertParam(
+        String accountId,
+        Long userId,
+        Long travelId,
+        Integer totalExpense,
+        Integer totalFood,
+        Integer totalActivity,
+        Integer totalAcc,
+        Integer totalTransport,
+        Integer totalShop
+) {
+}

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/req/TravelReportRequestDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/req/TravelReportRequestDTO.java
@@ -3,6 +3,5 @@ package org.scoula.controller.travel.report.dto.req;
 import java.time.LocalDateTime;
 
 public record TravelReportRequestDTO(
-        Long travelId,
-        Long userId // 선택: 여행 소유자 검증에 사용
+        Long travelId
 ) {}

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/req/TravelReportRequestDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/req/TravelReportRequestDTO.java
@@ -1,7 +1,12 @@
 package org.scoula.controller.travel.report.dto.req;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
 import java.time.LocalDateTime;
 
+@ApiModel(description = "여행 리포트 요청")
 public record TravelReportRequestDTO(
+        @ApiModelProperty(value = "Travel Id", example = "1")
         Long travelId
 ) {}

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/req/TravelReportRequestDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/req/TravelReportRequestDTO.java
@@ -1,0 +1,8 @@
+package org.scoula.controller.travel.report.dto.req;
+
+import java.time.LocalDateTime;
+
+public record TravelReportRequestDTO(
+        Long travelId,
+        Long userId // 선택: 여행 소유자 검증에 사용
+) {}

--- a/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/req/TravelReportSummary.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/report/dto/req/TravelReportSummary.java
@@ -1,0 +1,11 @@
+package org.scoula.controller.travel.report.dto.req;
+
+public record TravelReportSummary(
+        long totalExpense,
+        long totalFood,
+        long totalActivity,
+        long totalAcc,
+        long totalTransport,
+        long totalShop
+) {
+}

--- a/trippy-server/src/main/java/org/scoula/domain/travel/TravelLogVO.java
+++ b/trippy-server/src/main/java/org/scoula/domain/travel/TravelLogVO.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 public class TravelLogVO extends BaseTime {
 	private Long travelId;
 	private Long userId;
+	private String accountId;
 	private String title;
 	private LocalDateTime travelBeginDate;
 	private LocalDateTime travelEndDate;

--- a/trippy-server/src/main/java/org/scoula/mapper/travel/TravelReportMapper.java
+++ b/trippy-server/src/main/java/org/scoula/mapper/travel/TravelReportMapper.java
@@ -1,11 +1,20 @@
 package org.scoula.mapper.travel;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.scoula.domain.travel.TravelLogVO;
 import org.scoula.domain.travel.TravelReportVO;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 @Mapper
 public interface TravelReportMapper {
     TravelReportVO getTravelReport(Long travelId);
+    // travel_log에서 account_id + 기간 조회
+    TravelLogVO selectTravelLogInfo(@Param("travelId") Long travelId);
+
+    // 기간 내 거래 합계 조회 (withdraw 기준)
+    TravelReportVO selectExpenseSummary(@Param("param") ExpenseSummaryParam param);
+
+    int insertTravelReport(TravelReportVO vo);
 }

--- a/trippy-server/src/main/java/org/scoula/mapper/travel/TravelReportMapper.java
+++ b/trippy-server/src/main/java/org/scoula/mapper/travel/TravelReportMapper.java
@@ -1,20 +1,24 @@
 package org.scoula.mapper.travel;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.scoula.controller.travel.log.dto.res.TravelLogDTO;
+import org.scoula.controller.travel.report.dto.req.ExpenseSummaryParam;
+import org.scoula.controller.travel.report.dto.req.TravelReportInsertParam;
+import org.scoula.controller.travel.report.dto.req.TravelReportSummary;
 import org.scoula.domain.travel.TravelLogVO;
 import org.scoula.domain.travel.TravelReportVO;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Map;
 
 @Mapper
 public interface TravelReportMapper {
-    TravelReportVO getTravelReport(Long travelId);
-//    // travel_log에서 account_id + 기간 조회
-//    TravelLogVO selectTravelLogInfo(@Param("travelId") Long travelId);
-//
-//    // 기간 내 거래 합계 조회 (withdraw 기준)
-//    TravelReportVO selectExpenseSummary(@Param("param") ExpenseSummaryParam param);
-//
-//    int insertTravelReport(TravelReportVO vo);
+    TravelReportVO getTravelReport(@Param("travelId") Long travelId);
+
+    TravelLogVO selectTravelLog(@Param("travelId") Long travelId);
+
+    Map<String, Object> selectExpenseSummary(@Param("param") ExpenseSummaryParam p);
+
+    int insertTravelReport(@Param("param") TravelReportInsertParam p);
 }

--- a/trippy-server/src/main/java/org/scoula/mapper/travel/TravelReportMapper.java
+++ b/trippy-server/src/main/java/org/scoula/mapper/travel/TravelReportMapper.java
@@ -10,11 +10,11 @@ import java.util.List;
 @Mapper
 public interface TravelReportMapper {
     TravelReportVO getTravelReport(Long travelId);
-    // travel_log에서 account_id + 기간 조회
-    TravelLogVO selectTravelLogInfo(@Param("travelId") Long travelId);
-
-    // 기간 내 거래 합계 조회 (withdraw 기준)
-    TravelReportVO selectExpenseSummary(@Param("param") ExpenseSummaryParam param);
-
-    int insertTravelReport(TravelReportVO vo);
+//    // travel_log에서 account_id + 기간 조회
+//    TravelLogVO selectTravelLogInfo(@Param("travelId") Long travelId);
+//
+//    // 기간 내 거래 합계 조회 (withdraw 기준)
+//    TravelReportVO selectExpenseSummary(@Param("param") ExpenseSummaryParam param);
+//
+//    int insertTravelReport(TravelReportVO vo);
 }

--- a/trippy-server/src/main/java/org/scoula/mapper/travel/TravelReportMapper.java
+++ b/trippy-server/src/main/java/org/scoula/mapper/travel/TravelReportMapper.java
@@ -21,4 +21,6 @@ public interface TravelReportMapper {
     Map<String, Object> selectExpenseSummary(@Param("param") ExpenseSummaryParam p);
 
     int insertTravelReport(@Param("param") TravelReportInsertParam p);
+
+    int markTravelLogGenerated(@Param("travelId") Long travelId);
 }

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelLogService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelLogService.java
@@ -46,7 +46,7 @@ public class TravelLogService {
 				(String)log.get("destination"),
 				(Boolean)log.get("isGenerated"),
 				(String)log.get("travelImg"),
-				((Number)log.get("memberCount")).intValue()
+				((Number)log.get("memberCount")).longValue()
 			))
 			.toList();
 	}

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelLogService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelLogService.java
@@ -23,13 +23,6 @@ public class TravelLogService {
 	private final UserService userService;
 	private final S3Service s3Service;
 
-	//    public List<TravelLogDTO> getTravelLogs(final Long userId) {
-	//        userService.validateUserExists(userId);
-	//
-	//        return travelLogMapper.getAllTravelLogs(userId).stream()
-	//                .map(TravelLogDTO::from)
-	//                .toList();
-	//    }
 	public List<TravelLogDTO> getTravelLogs(final Long userId) {
 		userService.validateUserExists(userId);
 

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelLogService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelLogService.java
@@ -39,6 +39,7 @@ public class TravelLogService {
 			.map(log -> new TravelLogDTO(
 				((Number)log.get("travelId")).longValue(),
 				((Number)log.get("userId")).longValue(),
+				((String)log.get("accountId")),
 				(String)log.get("title"),
 				(LocalDateTime)log.get("travelBeginDate"),
 				(LocalDateTime)log.get("travelEndDate"),
@@ -58,6 +59,7 @@ public class TravelLogService {
 
 		TravelLogVO travelLog = TravelLogVO.builder()
 			.userId(userId)
+			.accountId(dto.accountId())
 			.title(dto.title())
 			.travelBeginDate(dto.travelBeginDate())
 			.travelEndDate(dto.travelEndDate())

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
@@ -1,6 +1,7 @@
 package org.scoula.service.travel;
 
 import lombok.RequiredArgsConstructor;
+import org.scoula.controller.travel.log.dto.res.TravelLogDTO;
 import org.scoula.controller.travel.report.dto.req.TravelReportRequestDTO;
 import org.scoula.controller.travel.report.dto.res.TravelReportDTO;
 import org.scoula.domain.travel.TravelLogVO;
@@ -18,61 +19,40 @@ public class TravelReportService {
     }
 
     /**
-     * 요청 바디의 travelId를 기준으로 travel_log에서 account_id/기간을 조회하고,
-     * 해당 account_id + user_id + 기간으로 transaction 집계 후 travel_report에 저장.
-     * @return 생성된 settlementId
+     * 1) travel_log에서 travelId로 account_id, user_id, 기간 조회
+     * 2) 그 기준으로 transaction 필터링(Withdraw만)
+     * 3) 총/카테고리별 소비 합계 계산
+     * 4) travel_report에 저장
      */
-    @Transactional
-    public long createTravelReport(final TravelReportRequestDTO req) {
-        if (req.travelId() == null) {
-            throw new IllegalArgumentException("travelId는 필수입니다.");
-        }
-
-        // 1) travel_log에서 account_id, user_id, 기간 조회
-        final TravelLogVO log = travelReportMapper.selectTravelLogInfo(req.travelId());
-        if (log == null) {
-            throw new IllegalArgumentException("해당 travelId의 여행이 존재하지 않습니다. travelId=" + req.travelId());
-        }
-
-        // (선택) userId 검증: 요청자와 여행 소유자가 같은지 확인
-        if (req.userId() != null && !req.userId().equals(log.getUserId())) {
-            throw new IllegalArgumentException("요청 사용자와 여행 소유자가 일치하지 않습니다.");
-        }
-
-        // 2) 기간 내 거래 합계 조회 (withdraw 기준)
-        ExpenseSummaryParam param = new ExpenseSummaryParam();
-        param.setAccountId(log.getAccountId());
-        param.setUserId(log.getUserId());
-        param.setStartDateTime(log.getTravelBeginDate());
-        param.setEndDateTime(log.getTravelEndDate());
-
-        TravelReportVO summary = travelReportMapper.selectExpenseSummary(param);
-        if (summary == null) {
-            summary = new TravelReportVO();
-            summary.setTotalExpense(0);
-            summary.setTotalFood(0);
-            summary.setTotalActivity(0);
-            summary.setTotalAcc(0);
-            summary.setTotalTransport(0);
-            summary.setTotalShop(0);
-        }
-
-        // 3) 저장
-        TravelReportVO toSave = new TravelReportVO();
-        toSave.setAccountId(log.getAccountId());
-        toSave.setUserId(log.getUserId());
-        toSave.setTravelId(req.travelId());
-        toSave.setTotalExpense(nz(summary.getTotalExpense()));
-        toSave.setTotalFood(nz(summary.getTotalFood()));
-        toSave.setTotalActivity(nz(summary.getTotalActivity()));
-        toSave.setTotalAcc(nz(summary.getTotalAcc()));
-        toSave.setTotalTransport(nz(summary.getTotalTransport()));
-        toSave.setTotalShop(nz(summary.getTotalShop()));
-
-        travelReportMapper.insertTravelReport(toSave); // useGeneratedKeys=true 가정
-        return toSave.getSettlementId();
-    }
-
-    private int nz(Integer v) { return v == null ? 0 : Math.max(0, v); }
-
+//    @Transactional
+//    public void createTravelReport(final TravelReportRequestDTO req) {
+//        if (req.travelId() == null) throw new IllegalArgumentException("travelId는 필수입니다.");
+//
+//        // 1) 여행 기본 정보 조회 (account_id, user_id, 기간)
+//        TravelLogDTO log = travelReportMapper.selectTravelLogInfo(req.travelId());
+//        if (log == null) throw new IllegalArgumentException("해당 travelId가 존재하지 않습니다: " + req.travelId());
+//
+//        // 2) 기간 내 거래 합계(출금/지출: withdraw) 조회
+//        ExpenseSummaryParam param = new ExpenseSummaryParam(
+//                log.accountId(), log.userId(), log.travelBeginDate(), log.travelEndDate()
+//        );
+//        TravelReportSummary sum = travelReportMapper.selectExpenseSummary(param);
+//        if (sum == null) sum = new TravelReportSummary(0,0,0,0,0,0);
+//
+//        // 3) 저장 파라미터 구성 → 4) 저장
+//        TravelReportInsertParam insert = new TravelReportInsertParam(
+//                log.accountId(),
+//                log.userId(),
+//                log.travelId(),
+//                nz(sum.totalExpense()),
+//                nz(sum.totalFood()),
+//                nz(sum.totalActivity()),
+//                nz(sum.totalAcc()),
+//                nz(sum.totalTransport()),
+//                nz(sum.totalShop())
+//        );
+//        travelReportMapper.insertTravelReport(insert);
+//    }
+//
+//    private int nz(Integer v) { return v == null ? 0 : Math.max(0, v); }
 }

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
@@ -1,14 +1,21 @@
 package org.scoula.service.travel;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.scoula.controller.travel.log.dto.res.TravelLogDTO;
+import org.scoula.controller.travel.report.dto.req.ExpenseSummaryParam;
+import org.scoula.controller.travel.report.dto.req.TravelReportInsertParam;
 import org.scoula.controller.travel.report.dto.req.TravelReportRequestDTO;
+import org.scoula.controller.travel.report.dto.req.TravelReportSummary;
 import org.scoula.controller.travel.report.dto.res.TravelReportDTO;
 import org.scoula.domain.travel.TravelLogVO;
 import org.scoula.mapper.travel.TravelReportMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TravelReportService {
@@ -19,40 +26,64 @@ public class TravelReportService {
     }
 
     /**
-     * 1) travel_log에서 travelId로 account_id, user_id, 기간 조회
-     * 2) 그 기준으로 transaction 필터링(Withdraw만)
-     * 3) 총/카테고리별 소비 합계 계산
-     * 4) travel_report에 저장
+     * 1) travel_log에서 account_id/user_id/기간 조회
+     * 2) 그 기준으로 transaction 집계( withdraw )
+     * 3) 총/카테고리별 합계 산출
+     * 4) travel_report 저장
      */
-//    @Transactional
-//    public void createTravelReport(final TravelReportRequestDTO req) {
-//        if (req.travelId() == null) throw new IllegalArgumentException("travelId는 필수입니다.");
-//
-//        // 1) 여행 기본 정보 조회 (account_id, user_id, 기간)
-//        TravelLogDTO log = travelReportMapper.selectTravelLogInfo(req.travelId());
-//        if (log == null) throw new IllegalArgumentException("해당 travelId가 존재하지 않습니다: " + req.travelId());
-//
-//        // 2) 기간 내 거래 합계(출금/지출: withdraw) 조회
-//        ExpenseSummaryParam param = new ExpenseSummaryParam(
-//                log.accountId(), log.userId(), log.travelBeginDate(), log.travelEndDate()
-//        );
-//        TravelReportSummary sum = travelReportMapper.selectExpenseSummary(param);
-//        if (sum == null) sum = new TravelReportSummary(0,0,0,0,0,0);
-//
-//        // 3) 저장 파라미터 구성 → 4) 저장
-//        TravelReportInsertParam insert = new TravelReportInsertParam(
-//                log.accountId(),
-//                log.userId(),
-//                log.travelId(),
-//                nz(sum.totalExpense()),
-//                nz(sum.totalFood()),
-//                nz(sum.totalActivity()),
-//                nz(sum.totalAcc()),
-//                nz(sum.totalTransport()),
-//                nz(sum.totalShop())
-//        );
-//        travelReportMapper.insertTravelReport(insert);
-//    }
-//
-//    private int nz(Integer v) { return v == null ? 0 : Math.max(0, v); }
+    @Transactional
+    public void createTravelReport(final TravelReportRequestDTO req) {
+        if (req.travelId() == null) throw new IllegalArgumentException("travelId는 필수입니다.");
+
+        final TravelLogVO travelLog = travelReportMapper.selectTravelLog(req.travelId());
+        if (travelLog == null) throw new IllegalArgumentException("해당 travelId가 존재하지 않습니다. travelId=" + req.travelId());
+        if (travelLog.getAccountId() == null || travelLog.getAccountId().isBlank())
+            throw new IllegalStateException("travel_log.account_id가 비어 있습니다. travelId=" + req.travelId());
+
+        log.info("[TR] step1 travelId={}, accountId={}, userId={}, begin={}, end={}",
+                travelLog.getTravelId(), travelLog.getAccountId(), travelLog.getUserId(),
+                travelLog.getTravelBeginDate(), travelLog.getTravelEndDate());
+
+        // 2) 집계 → Map
+        Map<String, Object> sum = travelReportMapper.selectExpenseSummary(
+                new ExpenseSummaryParam(
+                        travelLog.getAccountId(),
+                        travelLog.getUserId(),
+                        travelLog.getTravelBeginDate(),
+                        travelLog.getTravelEndDate()
+                )
+        );
+
+        long totalExpense   = n(sum, "totalExpense");
+        long totalFood      = n(sum, "totalFood");
+        long totalActivity  = n(sum, "totalActivity");
+        long totalAcc       = n(sum, "totalAcc");
+        long totalTransport = n(sum, "totalTransport");
+        long totalShop      = n(sum, "totalShop");
+
+        log.info("[TR] step2 summary=exp:{}, food:{}, act:{}, acc:{}, trans:{}, shop:{}",
+                totalExpense, totalFood, totalActivity, totalAcc, totalTransport, totalShop);
+
+        // 3)+4) 저장 (travel_report 컬럼이 INT라면 안전하게 변환)
+        var insert = new TravelReportInsertParam(
+                travelLog.getAccountId(),
+                travelLog.getUserId(),
+                travelLog.getTravelId(),
+                Math.toIntExact(totalExpense),
+                Math.toIntExact(totalFood),
+                Math.toIntExact(totalActivity),
+                Math.toIntExact(totalAcc),
+                Math.toIntExact(totalTransport),
+                Math.toIntExact(totalShop)
+        );
+        int rows = travelReportMapper.insertTravelReport(insert);
+
+        log.info("[TR] step3 inserted rows={}, travelId={}, accountId={}, userId={}",
+                rows, travelLog.getTravelId(), travelLog.getAccountId(), travelLog.getUserId());
+    }
+
+    private static long n(Map<String, Object> m, String k) {
+        Object v = (m == null) ? null : m.get(k);
+        return (v == null) ? 0L : ((Number) v).longValue();
+    }
 }

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
@@ -1,6 +1,8 @@
 package org.scoula.service.travel;
 
 import lombok.RequiredArgsConstructor;
+import org.scoula.common.exception.enums.ErrorCode;
+import org.scoula.common.exception.model.TrippyException;
 import org.scoula.controller.travel.log.dto.res.TravelLogDTO;
 import org.scoula.controller.travel.report.dto.req.ExpenseSummaryParam;
 import org.scoula.controller.travel.report.dto.req.TravelReportInsertParam;
@@ -32,14 +34,14 @@ public class TravelReportService {
     @Transactional
     public void createTravelReport(final TravelReportRequestDTO req) {
         if (req.travelId() == null)
-            throw new ApiException(TRAVEL_ID_REQUIRED);
+            throw new TrippyException(ErrorCode.TRAVEL_ID_REQUIRED);
 
         final TravelLogVO travelLog = travelReportMapper.selectTravelLog(req.travelId());
         if (travelLog == null)
-            throw new ApiException(TRAVEL_LOG_NOT_FOUND, req.travelId());
+            throw new TrippyException(ErrorCode.TRAVEL_LOG_NOT_FOUND);
 
         if (travelLog.getAccountId() == null || travelLog.getAccountId().isBlank())
-            throw new ApiException(TRAVEL_LOG_ACCOUNT_ID_EMPTY, req.travelId());
+            throw new TrippyException(ErrorCode.TRAVEL_LOG_ACCOUNT_ID_EMPTY);
 
         // 2) 집계 → Map
         Map<String, Object> sum = travelReportMapper.selectExpenseSummary(

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
@@ -1,7 +1,9 @@
 package org.scoula.service.travel;
 
 import lombok.RequiredArgsConstructor;
+import org.scoula.controller.travel.report.dto.req.TravelReportRequestDTO;
 import org.scoula.controller.travel.report.dto.res.TravelReportDTO;
+import org.scoula.domain.travel.TravelLogVO;
 import org.scoula.mapper.travel.TravelReportMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,5 +17,62 @@ public class TravelReportService {
         return TravelReportDTO.from(travelReportMapper.getTravelReport(travelId));
     }
 
+    /**
+     * 요청 바디의 travelId를 기준으로 travel_log에서 account_id/기간을 조회하고,
+     * 해당 account_id + user_id + 기간으로 transaction 집계 후 travel_report에 저장.
+     * @return 생성된 settlementId
+     */
+    @Transactional
+    public long createTravelReport(final TravelReportRequestDTO req) {
+        if (req.travelId() == null) {
+            throw new IllegalArgumentException("travelId는 필수입니다.");
+        }
+
+        // 1) travel_log에서 account_id, user_id, 기간 조회
+        final TravelLogVO log = travelReportMapper.selectTravelLogInfo(req.travelId());
+        if (log == null) {
+            throw new IllegalArgumentException("해당 travelId의 여행이 존재하지 않습니다. travelId=" + req.travelId());
+        }
+
+        // (선택) userId 검증: 요청자와 여행 소유자가 같은지 확인
+        if (req.userId() != null && !req.userId().equals(log.getUserId())) {
+            throw new IllegalArgumentException("요청 사용자와 여행 소유자가 일치하지 않습니다.");
+        }
+
+        // 2) 기간 내 거래 합계 조회 (withdraw 기준)
+        ExpenseSummaryParam param = new ExpenseSummaryParam();
+        param.setAccountId(log.getAccountId());
+        param.setUserId(log.getUserId());
+        param.setStartDateTime(log.getTravelBeginDate());
+        param.setEndDateTime(log.getTravelEndDate());
+
+        TravelReportVO summary = travelReportMapper.selectExpenseSummary(param);
+        if (summary == null) {
+            summary = new TravelReportVO();
+            summary.setTotalExpense(0);
+            summary.setTotalFood(0);
+            summary.setTotalActivity(0);
+            summary.setTotalAcc(0);
+            summary.setTotalTransport(0);
+            summary.setTotalShop(0);
+        }
+
+        // 3) 저장
+        TravelReportVO toSave = new TravelReportVO();
+        toSave.setAccountId(log.getAccountId());
+        toSave.setUserId(log.getUserId());
+        toSave.setTravelId(req.travelId());
+        toSave.setTotalExpense(nz(summary.getTotalExpense()));
+        toSave.setTotalFood(nz(summary.getTotalFood()));
+        toSave.setTotalActivity(nz(summary.getTotalActivity()));
+        toSave.setTotalAcc(nz(summary.getTotalAcc()));
+        toSave.setTotalTransport(nz(summary.getTotalTransport()));
+        toSave.setTotalShop(nz(summary.getTotalShop()));
+
+        travelReportMapper.insertTravelReport(toSave); // useGeneratedKeys=true 가정
+        return toSave.getSettlementId();
+    }
+
+    private int nz(Integer v) { return v == null ? 0 : Math.max(0, v); }
 
 }

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
@@ -80,6 +80,10 @@ public class TravelReportService {
 
         log.info("[TR] step3 inserted rows={}, travelId={}, accountId={}, userId={}",
                 rows, travelLog.getTravelId(), travelLog.getAccountId(), travelLog.getUserId());
+
+        int upd = travelReportMapper.markTravelLogGenerated(travelLog.getTravelId());
+        log.info("[TR] step4 mark generated travelId={}, updatedRows={}", travelLog.getTravelId(), upd);
+
     }
 
     private static long n(Map<String, Object> m, String k) {

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
@@ -1,7 +1,6 @@
 package org.scoula.service.travel;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.scoula.controller.travel.log.dto.res.TravelLogDTO;
 import org.scoula.controller.travel.report.dto.req.ExpenseSummaryParam;
 import org.scoula.controller.travel.report.dto.req.TravelReportInsertParam;
@@ -15,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TravelReportService {
@@ -33,12 +31,15 @@ public class TravelReportService {
      */
     @Transactional
     public void createTravelReport(final TravelReportRequestDTO req) {
-        if (req.travelId() == null) throw new IllegalArgumentException("travelId는 필수입니다.");
+        if (req.travelId() == null)
+            throw new ApiException(TRAVEL_ID_REQUIRED);
 
         final TravelLogVO travelLog = travelReportMapper.selectTravelLog(req.travelId());
-        if (travelLog == null) throw new IllegalArgumentException("해당 travelId가 존재하지 않습니다. travelId=" + req.travelId());
+        if (travelLog == null)
+            throw new ApiException(TRAVEL_LOG_NOT_FOUND, req.travelId());
+
         if (travelLog.getAccountId() == null || travelLog.getAccountId().isBlank())
-            throw new IllegalStateException("travel_log.account_id가 비어 있습니다. travelId=" + req.travelId());
+            throw new ApiException(TRAVEL_LOG_ACCOUNT_ID_EMPTY, req.travelId());
 
         // 2) 집계 → Map
         Map<String, Object> sum = travelReportMapper.selectExpenseSummary(
@@ -50,12 +51,12 @@ public class TravelReportService {
                 )
         );
 
-        long totalExpense   = n(sum, "totalExpense");
-        long totalFood      = n(sum, "totalFood");
-        long totalActivity  = n(sum, "totalActivity");
-        long totalAcc       = n(sum, "totalAcc");
-        long totalTransport = n(sum, "totalTransport");
-        long totalShop      = n(sum, "totalShop");
+        long totalExpense   = ((Number) sum.getOrDefault("totalExpense",   0L)).longValue();
+        long totalFood      = ((Number) sum.getOrDefault("totalFood",      0L)).longValue();
+        long totalActivity  = ((Number) sum.getOrDefault("totalActivity",  0L)).longValue();
+        long totalAcc       = ((Number) sum.getOrDefault("totalAcc",       0L)).longValue();
+        long totalTransport = ((Number) sum.getOrDefault("totalTransport", 0L)).longValue();
+        long totalShop      = ((Number) sum.getOrDefault("totalShop",      0L)).longValue();
 
         // 3)+4) 저장 (travel_report 컬럼이 INT라면 안전하게 변환)
         var insert = new TravelReportInsertParam(
@@ -73,10 +74,5 @@ public class TravelReportService {
 
         int upd = travelReportMapper.markTravelLogGenerated(travelLog.getTravelId());
 
-    }
-
-    private static long n(Map<String, Object> m, String k) {
-        Object v = (m == null) ? null : m.get(k);
-        return (v == null) ? 0L : ((Number) v).longValue();
     }
 }

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelReportService.java
@@ -40,10 +40,6 @@ public class TravelReportService {
         if (travelLog.getAccountId() == null || travelLog.getAccountId().isBlank())
             throw new IllegalStateException("travel_log.account_id가 비어 있습니다. travelId=" + req.travelId());
 
-        log.info("[TR] step1 travelId={}, accountId={}, userId={}, begin={}, end={}",
-                travelLog.getTravelId(), travelLog.getAccountId(), travelLog.getUserId(),
-                travelLog.getTravelBeginDate(), travelLog.getTravelEndDate());
-
         // 2) 집계 → Map
         Map<String, Object> sum = travelReportMapper.selectExpenseSummary(
                 new ExpenseSummaryParam(
@@ -61,9 +57,6 @@ public class TravelReportService {
         long totalTransport = n(sum, "totalTransport");
         long totalShop      = n(sum, "totalShop");
 
-        log.info("[TR] step2 summary=exp:{}, food:{}, act:{}, acc:{}, trans:{}, shop:{}",
-                totalExpense, totalFood, totalActivity, totalAcc, totalTransport, totalShop);
-
         // 3)+4) 저장 (travel_report 컬럼이 INT라면 안전하게 변환)
         var insert = new TravelReportInsertParam(
                 travelLog.getAccountId(),
@@ -78,11 +71,7 @@ public class TravelReportService {
         );
         int rows = travelReportMapper.insertTravelReport(insert);
 
-        log.info("[TR] step3 inserted rows={}, travelId={}, accountId={}, userId={}",
-                rows, travelLog.getTravelId(), travelLog.getAccountId(), travelLog.getUserId());
-
         int upd = travelReportMapper.markTravelLogGenerated(travelLog.getTravelId());
-        log.info("[TR] step4 mark generated travelId={}, updatedRows={}", travelLog.getTravelId(), upd);
 
     }
 

--- a/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelLogMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelLogMapper.xml
@@ -7,6 +7,7 @@
     <resultMap id="travelLogMap" type="org.scoula.domain.travel.TravelLogVO">
         <id property="travelId" column="travel_id"/>
         <result property="userId" column="user_id"/>
+        <result property="accountId" column="account_id"/>
         <result property="title" column="title"/>
         <result property="travelBeginDate" column="travel_begin_date"/>
         <result property="travelEndDate" column="travel_end_date"/>
@@ -22,6 +23,7 @@
         SELECT
             t.travel_id AS travelId,
             t.user_id AS userId,
+            t.account_id AS accountId,
             t.title,
             t.travel_begin_date AS travelBeginDate,
             t.travel_end_date AS travelEndDate,
@@ -40,12 +42,12 @@
 
     <insert id="save" parameterType="org.scoula.domain.travel.TravelLogVO">
         INSERT INTO travel_log (
-            user_id, title, travel_begin_date, travel_end_date,
+            user_id, account_id, title, travel_begin_date, travel_end_date,
             destination, is_generated, travel_img,
             created_at, updated_at
         )
         VALUES (
-                   #{userId}, #{title}, #{travelBeginDate}, #{travelEndDate},
+                   #{userId}, #{accountId}, #{title}, #{travelBeginDate}, #{travelEndDate},
                    #{destination}, #{isGenerated}, #{travelImg},
                    NOW(), NOW()
                )

--- a/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelReportMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelReportMapper.xml
@@ -50,4 +50,57 @@
                                AND tx.created_at BETWEEN tl.travel_begin_date AND tl.travel_end_date
         WHERE tl.travel_id = #{travelId}
     </select>
+
+    <select id="selectTravelLogInfo" resultType="org.scoula.domain.travel.TravelLogInfoVO">
+        SELECT
+            tl.travel_id           AS travelId,
+            tl.user_id             AS userId,
+            tl.account_id          AS accountId,
+            tl.travel_begin_date   AS travelBeginDate,
+            tl.travel_end_date     AS travelEndDate
+        FROM travel_log tl
+        WHERE tl.travel_id = #{travelId}
+            LIMIT 1
+    </select>
+
+    <select id="selectExpenseSummary" parameterType="map"
+            resultType="org.scoula.domain.travel.TravelReportVO">
+        SELECT
+            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'
+                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalExpense,
+            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'
+                AND LOWER(t.category) = 'food'
+                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalFood,
+            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'
+                AND LOWER(t.category) = 'activity'
+                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalActivity,
+            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'
+                AND LOWER(t.category) = 'acc'
+                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalAcc,
+            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'
+                AND LOWER(t.category) = 'transport'
+                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalTransport,
+            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'
+                AND LOWER(t.category) = 'shop'
+                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalShop
+        FROM `transaction` t
+        WHERE t.account_id = #{param.accountId}
+          AND t.user_id    = #{param.userId}
+          AND t.created_at BETWEEN #{param.startDateTime} AND #{param.endDateTime}
+    </select>
+
+    <!-- travel_report 저장 -->
+    <insert id="insertTravelReport"
+            parameterType="org.scoula.domain.travel.TravelReportVO"
+            useGeneratedKeys="true" keyProperty="settlementId">
+        INSERT INTO travel_report(
+            account_id, user_id, travel_id,
+            total_expense, total_food, total_activity, total_acc, total_transport, total_shop
+        ) VALUES (
+                     #{accountId}, #{userId}, #{travelId},
+                     #{totalExpense}, #{totalFood}, #{totalActivity}, #{totalAcc}, #{totalTransport}, #{totalShop}
+                 )
+    </insert>
+
+
 </mapper>

--- a/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelReportMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelReportMapper.xml
@@ -41,8 +41,8 @@
                  JOIN travel_report tr ON tl.travel_id = tr.travel_id
                  LEFT JOIN (
             SELECT t.account_id, t.title, t.amount, t.created_at
-            FROM transaction t
-            WHERE t.transaction_type = '지출'
+            FROM `transaction` t
+            WHERE LOWER(TRIM(t.transaction_type)) = 'withdraw'
             ORDER BY t.amount DESC
                 LIMIT 1
         ) tx
@@ -51,56 +51,47 @@
         WHERE tl.travel_id = #{travelId}
     </select>
 
-<!--    <select id="selectTravelLogInfo" resultType="org.scoula.domain.travel.TravelLogInfoVO">-->
-<!--        SELECT-->
-<!--            tl.travel_id           AS travelId,-->
-<!--            tl.user_id             AS userId,-->
-<!--            tl.account_id          AS accountId,-->
-<!--            tl.travel_begin_date   AS travelBeginDate,-->
-<!--            tl.travel_end_date     AS travelEndDate-->
-<!--        FROM travel_log tl-->
-<!--        WHERE tl.travel_id = #{travelId}-->
-<!--            LIMIT 1-->
-<!--    </select>-->
+    <select id="selectTravelLog" resultType="org.scoula.domain.travel.TravelLogVO">
+        SELECT
+            tl.travel_id         AS travelId,
+            tl.user_id           AS userId,
+            tl.account_id        AS accountId,
+            tl.title             AS title,
+            tl.travel_begin_date AS travelBeginDate,
+            tl.travel_end_date   AS travelEndDate,
+            tl.destination       AS destination,
+            tl.is_generated      AS isGenerated,
+            tl.travel_img        AS travelImg
+        FROM travel_log tl
+        WHERE tl.travel_id = #{travelId}
+    </select>
 
-<!--    <select id="selectExpenseSummary" parameterType="map"-->
-<!--            resultType="org.scoula.domain.travel.TravelReportVO">-->
-<!--        SELECT-->
-<!--            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'-->
-<!--                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalExpense,-->
-<!--            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'-->
-<!--                AND LOWER(t.category) = 'food'-->
-<!--                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalFood,-->
-<!--            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'-->
-<!--                AND LOWER(t.category) = 'activity'-->
-<!--                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalActivity,-->
-<!--            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'-->
-<!--                AND LOWER(t.category) = 'acc'-->
-<!--                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalAcc,-->
-<!--            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'-->
-<!--                AND LOWER(t.category) = 'transport'-->
-<!--                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalTransport,-->
-<!--            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'-->
-<!--                AND LOWER(t.category) = 'shop'-->
-<!--                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalShop-->
-<!--        FROM `transaction` t-->
-<!--        WHERE t.account_id = #{param.accountId}-->
-<!--          AND t.user_id    = #{param.userId}-->
-<!--          AND t.created_at BETWEEN #{param.startDateTime} AND #{param.endDateTime}-->
-<!--    </select>-->
+    <select id="selectExpenseSummary" resultType="map">
+        SELECT
+            COALESCE(SUM(CASE WHEN LOWER(TRIM(t.transaction_type))='withdraw' THEN ABS(t.amount) ELSE 0 END), 0) AS totalExpense,
+            COALESCE(SUM(CASE WHEN LOWER(TRIM(t.transaction_type))='withdraw' AND LOWER(TRIM(t.category))='food'      THEN ABS(t.amount) ELSE 0 END), 0) AS totalFood,
+            COALESCE(SUM(CASE WHEN LOWER(TRIM(t.transaction_type))='withdraw' AND LOWER(TRIM(t.category))='activity'  THEN ABS(t.amount) ELSE 0 END), 0) AS totalActivity,
+            COALESCE(SUM(CASE WHEN LOWER(TRIM(t.transaction_type))='withdraw' AND LOWER(TRIM(t.category))='acc'       THEN ABS(t.amount) ELSE 0 END), 0) AS totalAcc,
+            COALESCE(SUM(CASE WHEN LOWER(TRIM(t.transaction_type))='withdraw' AND LOWER(TRIM(t.category))='transport' THEN ABS(t.amount) ELSE 0 END), 0) AS totalTransport,
+            COALESCE(SUM(CASE WHEN LOWER(TRIM(t.transaction_type))='withdraw' AND LOWER(TRIM(t.category))='shop'      THEN ABS(t.amount) ELSE 0 END), 0) AS totalShop
+        FROM `transaction` t
+        WHERE t.account_id = #{param.accountId}
+          AND t.user_id    = #{param.userId}
+          AND t.created_at &gt;= #{param.startDateTime}
+          AND t.created_at &lt;  DATE_ADD(#{param.endDateTime}, INTERVAL 1 DAY)
+    </select>
 
-<!--    &lt;!&ndash; travel_report 저장 &ndash;&gt;-->
-<!--    <insert id="insertTravelReport"-->
-<!--            parameterType="org.scoula.domain.travel.TravelReportVO"-->
-<!--            useGeneratedKeys="true" keyProperty="settlementId">-->
-<!--        INSERT INTO travel_report(-->
-<!--            account_id, user_id, travel_id,-->
-<!--            total_expense, total_food, total_activity, total_acc, total_transport, total_shop-->
-<!--        ) VALUES (-->
-<!--                     #{accountId}, #{userId}, #{travelId},-->
-<!--                     #{totalExpense}, #{totalFood}, #{totalActivity}, #{totalAcc}, #{totalTransport}, #{totalShop}-->
-<!--                 )-->
-<!--    </insert>-->
+    <!-- 4) travel_report 저장 -->
+    <insert id="insertTravelReport">
+        INSERT INTO travel_report (
+            account_id, user_id, travel_id,
+            total_expense, total_food, total_activity, total_acc, total_transport, total_shop
+        ) VALUES (
+                     #{param.accountId}, #{param.userId}, #{param.travelId},
+                     #{param.totalExpense}, #{param.totalFood}, #{param.totalActivity},
+                     #{param.totalAcc}, #{param.totalTransport}, #{param.totalShop}
+                 )
+    </insert>
 
 
 </mapper>

--- a/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelReportMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelReportMapper.xml
@@ -51,56 +51,56 @@
         WHERE tl.travel_id = #{travelId}
     </select>
 
-    <select id="selectTravelLogInfo" resultType="org.scoula.domain.travel.TravelLogInfoVO">
-        SELECT
-            tl.travel_id           AS travelId,
-            tl.user_id             AS userId,
-            tl.account_id          AS accountId,
-            tl.travel_begin_date   AS travelBeginDate,
-            tl.travel_end_date     AS travelEndDate
-        FROM travel_log tl
-        WHERE tl.travel_id = #{travelId}
-            LIMIT 1
-    </select>
+<!--    <select id="selectTravelLogInfo" resultType="org.scoula.domain.travel.TravelLogInfoVO">-->
+<!--        SELECT-->
+<!--            tl.travel_id           AS travelId,-->
+<!--            tl.user_id             AS userId,-->
+<!--            tl.account_id          AS accountId,-->
+<!--            tl.travel_begin_date   AS travelBeginDate,-->
+<!--            tl.travel_end_date     AS travelEndDate-->
+<!--        FROM travel_log tl-->
+<!--        WHERE tl.travel_id = #{travelId}-->
+<!--            LIMIT 1-->
+<!--    </select>-->
 
-    <select id="selectExpenseSummary" parameterType="map"
-            resultType="org.scoula.domain.travel.TravelReportVO">
-        SELECT
-            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'
-                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalExpense,
-            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'
-                AND LOWER(t.category) = 'food'
-                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalFood,
-            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'
-                AND LOWER(t.category) = 'activity'
-                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalActivity,
-            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'
-                AND LOWER(t.category) = 'acc'
-                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalAcc,
-            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'
-                AND LOWER(t.category) = 'transport'
-                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalTransport,
-            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'
-                AND LOWER(t.category) = 'shop'
-                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalShop
-        FROM `transaction` t
-        WHERE t.account_id = #{param.accountId}
-          AND t.user_id    = #{param.userId}
-          AND t.created_at BETWEEN #{param.startDateTime} AND #{param.endDateTime}
-    </select>
+<!--    <select id="selectExpenseSummary" parameterType="map"-->
+<!--            resultType="org.scoula.domain.travel.TravelReportVO">-->
+<!--        SELECT-->
+<!--            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'-->
+<!--                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalExpense,-->
+<!--            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'-->
+<!--                AND LOWER(t.category) = 'food'-->
+<!--                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalFood,-->
+<!--            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'-->
+<!--                AND LOWER(t.category) = 'activity'-->
+<!--                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalActivity,-->
+<!--            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'-->
+<!--                AND LOWER(t.category) = 'acc'-->
+<!--                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalAcc,-->
+<!--            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'-->
+<!--                AND LOWER(t.category) = 'transport'-->
+<!--                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalTransport,-->
+<!--            COALESCE(SUM(CASE WHEN t.transaction_type = 'withdraw'-->
+<!--                AND LOWER(t.category) = 'shop'-->
+<!--                                  THEN ABS(t.amount) ELSE 0 END), 0) AS totalShop-->
+<!--        FROM `transaction` t-->
+<!--        WHERE t.account_id = #{param.accountId}-->
+<!--          AND t.user_id    = #{param.userId}-->
+<!--          AND t.created_at BETWEEN #{param.startDateTime} AND #{param.endDateTime}-->
+<!--    </select>-->
 
-    <!-- travel_report 저장 -->
-    <insert id="insertTravelReport"
-            parameterType="org.scoula.domain.travel.TravelReportVO"
-            useGeneratedKeys="true" keyProperty="settlementId">
-        INSERT INTO travel_report(
-            account_id, user_id, travel_id,
-            total_expense, total_food, total_activity, total_acc, total_transport, total_shop
-        ) VALUES (
-                     #{accountId}, #{userId}, #{travelId},
-                     #{totalExpense}, #{totalFood}, #{totalActivity}, #{totalAcc}, #{totalTransport}, #{totalShop}
-                 )
-    </insert>
+<!--    &lt;!&ndash; travel_report 저장 &ndash;&gt;-->
+<!--    <insert id="insertTravelReport"-->
+<!--            parameterType="org.scoula.domain.travel.TravelReportVO"-->
+<!--            useGeneratedKeys="true" keyProperty="settlementId">-->
+<!--        INSERT INTO travel_report(-->
+<!--            account_id, user_id, travel_id,-->
+<!--            total_expense, total_food, total_activity, total_acc, total_transport, total_shop-->
+<!--        ) VALUES (-->
+<!--                     #{accountId}, #{userId}, #{travelId},-->
+<!--                     #{totalExpense}, #{totalFood}, #{totalActivity}, #{totalAcc}, #{totalTransport}, #{totalShop}-->
+<!--                 )-->
+<!--    </insert>-->
 
 
 </mapper>

--- a/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelReportMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelReportMapper.xml
@@ -93,5 +93,13 @@
                  )
     </insert>
 
+    <update id="markTravelLogGenerated">
+        UPDATE travel_log
+        SET is_generated = 1,
+            updated_at   = NOW()
+        WHERE travel_id    = #{travelId}
+          AND is_generated = 0
+    </update>
+
 
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #74

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
4H/2일

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->

travel_log에 account_id 컬럼을 추가하였습니다.
travelId를 입력으로 받아 해당 여행과 연결된 계좌 정보를 travel_log 테이블에서 가져옵니다.
계좌 데이터와 여행 기간을 통해 transaction 테이블에서 거래 내역을 필터링하고 전체소비/카테고리별 소비 합산 데이터를 계산합니다
합산한 데이터를 travel_report에 저장합니다.
travel_log에 여행 리포트 생성 여부 컬럼인 is_generated 를 0에서 1로 업데이트합니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
