### PR TITLE
[fix] 환율 조회 쿼리문 수정

### DIFF
--- a/trippy-server/src/main/java/org/scoula/service/exchange/ExchangeRateService.java
+++ b/trippy-server/src/main/java/org/scoula/service/exchange/ExchangeRateService.java
@@ -61,7 +61,6 @@ public class ExchangeRateService {
 
 			ExchangeRateVO todayData = currencyData.get(0);
 			ExchangeRateVO yesterdayData = currencyData.get(1);
-
 			result.add(calculateExchangeRateComparison(todayData, yesterdayData));
 		}
 		return result;

--- a/trippy-server/src/main/resources/org/scoula/mapper/exchange/ExchangeRateMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/exchange/ExchangeRateMapper.xml
@@ -74,10 +74,14 @@
         SELECT *
         FROM exchange_rate
         WHERE DATE(exchange_rate_date) IN (
-            CURDATE(),
-            DATE_SUB(CURDATE(), INTERVAL 1 DAY)
+            SELECT d FROM (
+            SELECT DISTINCT DATE(exchange_rate_date) AS d
+            FROM exchange_rate
+            ORDER BY d DESC
+            LIMIT 2
+            ) AS t
             )
-        ORDER BY currency_code, exchange_rate_date DESC
+        ORDER BY currency_code, exchange_rate_date DESC;
     </select>
 
     <!-- 환전 기능 -->


### PR DESCRIPTION
- 현재 날짜 기준에서 DB상 최근 2일치 조회하도록 수정

## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #125

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
5분/5분

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->

[기존 쿼리문] - 현재날짜 기준 최신 환율 정보 조회

```<select id="getRecentTwoDaysExchangeRates" resultType="org.scoula.domain.exchange.ExchangeRateVO"> SELECT * FROM exchange_rate WHERE DATE(exchange_rate_date) IN ( CURDATE(), DATE_SUB(CURDATE(), INTERVAL 1 DAY) ) ORDER BY currency_code, exchange_rate_date DESC </select>```

[ 수정 후 쿼리문] - DB에 저장된 환율 정보 중 가장 최신 2일 분 조회하는 로직으로 변경
```
SELECT *
FROM exchange_rate
WHERE DATE(exchange_rate_date) IN (
  SELECT d FROM (
    SELECT DISTINCT DATE(exchange_rate_date) AS d
    FROM exchange_rate
    ORDER BY d DESC
    LIMIT 2
  ) AS t
)
ORDER BY currency_code, exchange_rate_date DESC;
```


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
현재 DB상 가장 최근 2일치를 조회하도록 쿼리문 수정했습니다.