### PR TITLE
[FEAT] 여행로그에서의 결제 내역 단건 조회 (#76)

### DIFF
--- a/trippy-server/src/main/java/org/scoula/common/exception/GlobalExceptionHandler.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/GlobalExceptionHandler.java
@@ -6,19 +6,30 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import lombok.extern.log4j.Log4j2;
+
 @RestControllerAdvice
+@Log4j2
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(TrippyException.class)
 	public ResponseEntity<ErrorResponse> handleTrippyException(TrippyException ex) {
+		// 로그 추가
+		log.error("TrippyException 발생: {}", ex.getMessage(), ex);
+
 		return ResponseEntity
 			.status(ex.getErrorCode().getHttpStatus())
 			.body(ErrorResponse.error(ex.getErrorCode()));
 	}
 
-	// Optional: 그 외 예상치 못한 예외 처리
+	// 일반 예외 처리
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {
+		log.error("=== 500서버 에러 발생 ===");
+		log.error("에러 타입: {}", ex.getClass().getSimpleName());
+		log.error("에러 메시지: {}", ex.getMessage());
+		log.error("스택트레이스: ", ex);
+
 		return ResponseEntity
 			.internalServerError()
 			.body(ErrorResponse.badRequestError("서버 내부 오류가 발생했습니다."));

--- a/trippy-server/src/main/java/org/scoula/common/exception/enums/SuccessCode.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/enums/SuccessCode.java
@@ -68,7 +68,9 @@ public enum SuccessCode {
 	//여행로그
 	FIND_TRAVEL_LOG_SUCCESS(HttpStatus.OK, "여행 로그 조회 성공"),
 	FIND_TRAVEL_REPORT_SUCCESS(HttpStatus.OK, "여행 리포트 조회 성공"),
-	CREATE_TRAVEL_LOG_SUCCESS(HttpStatus.OK, "여행 로그 생성 성공");
+	CREATE_TRAVEL_LOG_SUCCESS(HttpStatus.OK, "여행 로그 생성 성공"),
+	FIND_TRAVEL_LOG_TRANSACTIONS_SUCCESS(HttpStatus.OK, "여행 기간 동안의 결제 내역 전체 조회 성공"),
+	FIND_TRAVEL_LOG_DETAIL_TRANSACTION_SUCCESS(HttpStatus.OK, "여행 로그 거래 상세 조회 성공");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/TravelLogController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/TravelLogController.java
@@ -11,6 +11,7 @@ import org.scoula.common.dto.SuccessNonDataResponse;
 import org.scoula.common.dto.SuccessResponse;
 import org.scoula.common.exception.enums.SuccessCode;
 import org.scoula.controller.travel.log.dto.req.TravelLogCreateDTO;
+import org.scoula.controller.travel.log.dto.req.TravelLogTransactionListDTO;
 import org.scoula.controller.travel.log.dto.res.TravelLogDTO;
 import org.scoula.service.travel.TravelLogService;
 
@@ -63,6 +64,20 @@ public class TravelLogController {
 	) {
 		travelLogService.createTravelLog(userId, travelLogCreateDTO, travelImg);
 		return SuccessNonDataResponse.success(SuccessCode.CREATE_TRAVEL_LOG_SUCCESS);
+	}
+
+	@ApiOperation(value = "[JWT] [지도뷰 보기] 여행 로그에서의 여행 기간 동안의 결제 내역 전체 조회", notes = "지도에 핀으로 보여질 결제 내역들 리스트 API입니다.")
+	@ApiResponses(value = {
+		@ApiResponse(code = 200, message = "여행 기간 동안의 결제 내역 전체 조회 성공", response = SuccessResponse.class),
+		@ApiResponse(code = 404, message = "해당 유저가 존재하지 않습니다.", response = ErrorResponse.class)
+	})
+	@GetMapping("/{travelId}")
+	public SuccessResponse<TravelLogTransactionListDTO> getTravelLogs(
+		@ApiParam(value = "유저 ID", required = true, example = "1")
+		@RequestParam Long userId,
+		@ApiParam(value = "여행 ID", required = true, example = "1")
+		@PathVariable Long travelId) {
+		return SuccessResponse.success(SuccessCode.FIND_TRAVEL_LOG_TRANSACTIONS_SUCCESS, travelLogService.getTravelTransactions(userId, travelId));
 	}
 
 }

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/TravelLogController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/TravelLogController.java
@@ -73,6 +73,7 @@ public class TravelLogController {
 	})
 	@GetMapping("/{travelId}")
 	public SuccessResponse<TravelLogTransactionListDTO> getTravelLogs(
+		//@ApiIgnore @UserId Long userId => 이걸로 바꿀 예정입니다... 그래서 userId 안 받아와도됨 travelId만!
 		@ApiParam(value = "유저 ID", required = true, example = "1")
 		@RequestParam Long userId,
 		@ApiParam(value = "여행 ID", required = true, example = "1")

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/TravelLogController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/TravelLogController.java
@@ -10,6 +10,7 @@ import org.scoula.common.dto.ErrorResponse;
 import org.scoula.common.dto.SuccessNonDataResponse;
 import org.scoula.common.dto.SuccessResponse;
 import org.scoula.common.exception.enums.SuccessCode;
+import org.scoula.config.resolver.UserId;
 import org.scoula.controller.travel.log.dto.req.TravelLogCreateDTO;
 import org.scoula.controller.travel.log.dto.req.TravelLogTransactionDTO;
 import org.scoula.controller.travel.log.dto.req.TravelLogTransactionListDTO;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
+import springfox.documentation.annotations.ApiIgnore;
 
 import org.springframework.web.multipart.MultipartFile;
 
@@ -89,9 +91,7 @@ public class TravelLogController {
 	})
 	@GetMapping("/{travelId}/{transactionId}")
 	public SuccessResponse<TravelLogTransactionDTO> getTravelLogs(
-		//@ApiIgnore @UserId Long userId => 이걸로 바꿀 예정입니다... 그래서 userId 안 받아와도됨 travelId만!
-		@ApiParam(value = "유저 ID", required = true, example = "1")
-		@RequestParam Long userId,
+		@ApiIgnore @UserId Long userId,
 		@ApiParam(value = "여행 ID", required = true, example = "1")
 		@PathVariable Long travelId,
 		@ApiParam(value = "거래내역 ID", required = true, example = "23")

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/TravelLogController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/TravelLogController.java
@@ -11,6 +11,7 @@ import org.scoula.common.dto.SuccessNonDataResponse;
 import org.scoula.common.dto.SuccessResponse;
 import org.scoula.common.exception.enums.SuccessCode;
 import org.scoula.controller.travel.log.dto.req.TravelLogCreateDTO;
+import org.scoula.controller.travel.log.dto.req.TravelLogTransactionDTO;
 import org.scoula.controller.travel.log.dto.req.TravelLogTransactionListDTO;
 import org.scoula.controller.travel.log.dto.res.TravelLogDTO;
 import org.scoula.service.travel.TravelLogService;
@@ -79,6 +80,23 @@ public class TravelLogController {
 		@ApiParam(value = "여행 ID", required = true, example = "1")
 		@PathVariable Long travelId) {
 		return SuccessResponse.success(SuccessCode.FIND_TRAVEL_LOG_TRANSACTIONS_SUCCESS, travelLogService.getTravelTransactions(userId, travelId));
+	}
+
+	@ApiOperation(value = "[JWT] [지도뷰 상세 보기] 여행 로그에서의 여행 기간 동안의 결제 내역 전체 조회", notes = "지도에 핀으로 보여질 결제 내역들 리스트 API입니다.")
+	@ApiResponses(value = {
+		@ApiResponse(code = 200, message = "여행 기간 동안의 결제 내역 전체 조회 성공", response = SuccessResponse.class),
+		@ApiResponse(code = 404, message = "해당 유저가 존재하지 않습니다.", response = ErrorResponse.class)
+	})
+	@GetMapping("/{travelId}/{transactionId}")
+	public SuccessResponse<TravelLogTransactionDTO> getTravelLogs(
+		//@ApiIgnore @UserId Long userId => 이걸로 바꿀 예정입니다... 그래서 userId 안 받아와도됨 travelId만!
+		@ApiParam(value = "유저 ID", required = true, example = "1")
+		@RequestParam Long userId,
+		@ApiParam(value = "여행 ID", required = true, example = "1")
+		@PathVariable Long travelId,
+		@ApiParam(value = "거래내역 ID", required = true, example = "23")
+		@PathVariable Long transactionId) {
+		return SuccessResponse.success(SuccessCode.FIND_TRAVEL_LOG_DETAIL_TRANSACTION_SUCCESS, travelLogService.getTravelLogDetailTransaction(transactionId));
 	}
 
 }

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/req/TravelLogTransactionDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/req/TravelLogTransactionDTO.java
@@ -1,0 +1,24 @@
+package org.scoula.controller.travel.log.dto.req;
+
+import java.time.LocalDateTime;
+
+import org.scoula.domain.transaction.TransactionCategory;
+import org.scoula.domain.transaction.TransactionVO;
+
+public record TravelLogTransactionDTO(
+	Long transactionId,
+	TransactionCategory category,
+	Long amount,
+	LocalDateTime createdAt,
+	String title
+) {
+	public static TravelLogTransactionDTO from(TransactionVO transaction) {
+		return new TravelLogTransactionDTO(
+			transaction.getTransactionId(),
+			transaction.getCategory(),
+			transaction.getAmount(),
+			transaction.getCreatedAt(),
+			transaction.getTitle()
+		);
+	}
+}

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/req/TravelLogTransactionDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/req/TravelLogTransactionDTO.java
@@ -10,7 +10,9 @@ public record TravelLogTransactionDTO(
 	TransactionCategory category,
 	Long amount,
 	LocalDateTime createdAt,
-	String title
+	String title,
+	String latitude,
+	String longitude
 ) {
 	public static TravelLogTransactionDTO from(TransactionVO transaction) {
 		return new TravelLogTransactionDTO(
@@ -18,7 +20,9 @@ public record TravelLogTransactionDTO(
 			transaction.getCategory(),
 			transaction.getAmount(),
 			transaction.getCreatedAt(),
-			transaction.getTitle()
+			transaction.getTitle(),
+			transaction.getLatitude(),
+			transaction.getLongitude()
 		);
 	}
 }

--- a/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/req/TravelLogTransactionListDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/travel/log/dto/req/TravelLogTransactionListDTO.java
@@ -1,0 +1,11 @@
+package org.scoula.controller.travel.log.dto.req;
+
+import java.util.List;
+
+public record TravelLogTransactionListDTO(
+	Long travelId,
+	Long todayAmount,
+	Long totalAmount,
+	List<TravelLogTransactionDTO> travelLogTransactionDTOS
+) {
+}

--- a/trippy-server/src/main/java/org/scoula/domain/travel/TravelLogVO.java
+++ b/trippy-server/src/main/java/org/scoula/domain/travel/TravelLogVO.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 public class TravelLogVO extends BaseTime {
 	private Long travelId;
 	private Long userId;
+	private String accountId;
 	private String title;
 	private LocalDateTime travelBeginDate;
 	private LocalDateTime travelEndDate;

--- a/trippy-server/src/main/java/org/scoula/mapper/transaction/TransactionMapper.java
+++ b/trippy-server/src/main/java/org/scoula/mapper/transaction/TransactionMapper.java
@@ -20,4 +20,6 @@ public interface TransactionMapper {
 	List<TransactionVO> findExpenseTransactionsByAccountId(@Param("userId") Long userId,
 		@Param("accountId") String accountId, @Param("startDate") LocalDateTime startDate,
 		@Param("endDate") LocalDateTime endDate);
+
+	TransactionVO findByTransactionId(Long transactionId);
 }

--- a/trippy-server/src/main/java/org/scoula/mapper/transaction/TransactionMapper.java
+++ b/trippy-server/src/main/java/org/scoula/mapper/transaction/TransactionMapper.java
@@ -1,5 +1,6 @@
 package org.scoula.mapper.transaction;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
@@ -10,8 +11,13 @@ import org.scoula.domain.transaction.TransactionVO;
 public interface TransactionMapper {
 
 	void saveTransaction(TransactionVO transactionVO);
+
 	List<TransactionVO> getAccountTransaction(String accountId);
 
 	List<TransactionVO> filterAccountTransactions(@Param("accountId") String accountId,
 		@Param("transactionType") String transactionType);
+
+	List<TransactionVO> findExpenseTransactionsByAccountId(@Param("userId") Long userId,
+		@Param("accountId") String accountId, @Param("startDate") LocalDateTime startDate,
+		@Param("endDate") LocalDateTime endDate);
 }

--- a/trippy-server/src/main/java/org/scoula/mapper/travel/TravelLogMapper.java
+++ b/trippy-server/src/main/java/org/scoula/mapper/travel/TravelLogMapper.java
@@ -11,4 +11,6 @@ import org.springframework.data.repository.query.Param;
 public interface TravelLogMapper {
     List<Map<String, Object>> getAllTravelLogs(@Param("userId") Long userId);
     void save(TravelLogVO travelLogVO);
+
+    TravelLogVO findByTravelId(@Param("travelId") Long travelId);
 }

--- a/trippy-server/src/main/java/org/scoula/service/transaction/TransactionService.java
+++ b/trippy-server/src/main/java/org/scoula/service/transaction/TransactionService.java
@@ -1,0 +1,23 @@
+package org.scoula.service.transaction;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.scoula.domain.transaction.TransactionVO;
+import org.scoula.mapper.transaction.TransactionMapper;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class TransactionService {
+
+	private final TransactionMapper transactionMapper;
+
+	public List<TransactionVO> getUserExpenseTransactions(Long userId, String accountId, LocalDateTime startDate, LocalDateTime endDate){
+		return transactionMapper.findExpenseTransactionsByAccountId(userId, accountId, startDate, endDate);
+	}
+}

--- a/trippy-server/src/main/java/org/scoula/service/transaction/TransactionService.java
+++ b/trippy-server/src/main/java/org/scoula/service/transaction/TransactionService.java
@@ -17,7 +17,12 @@ public class TransactionService {
 
 	private final TransactionMapper transactionMapper;
 
-	public List<TransactionVO> getUserExpenseTransactions(Long userId, String accountId, LocalDateTime startDate, LocalDateTime endDate){
+	public List<TransactionVO> getUserExpenseTransactions(Long userId, String accountId, LocalDateTime startDate,
+		LocalDateTime endDate) {
 		return transactionMapper.findExpenseTransactionsByAccountId(userId, accountId, startDate, endDate);
+	}
+
+	public TransactionVO getTransaction(Long transactionId) {
+		return transactionMapper.findByTransactionId(transactionId);
 	}
 }

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelLogService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelLogService.java
@@ -111,4 +111,13 @@ public class TravelLogService {
 			.sum();
 	}
 
+	/***
+	 * 여행 기간동안의 거래 내역 상세 조회 ( 단건 조회 )
+	 * @param transactionId
+	 * @return
+	 */
+	public TravelLogTransactionDTO getTravelLogDetailTransaction(final Long transactionId) {
+		return TravelLogTransactionDTO.from(transactionService.getTransaction(transactionId));
+	}
+
 }

--- a/trippy-server/src/main/java/org/scoula/service/travel/TravelLogService.java
+++ b/trippy-server/src/main/java/org/scoula/service/travel/TravelLogService.java
@@ -1,5 +1,6 @@
 package org.scoula.service.travel;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -7,10 +8,14 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 
 import org.scoula.controller.travel.log.dto.req.TravelLogCreateDTO;
+import org.scoula.controller.travel.log.dto.req.TravelLogTransactionDTO;
+import org.scoula.controller.travel.log.dto.req.TravelLogTransactionListDTO;
 import org.scoula.controller.travel.log.dto.res.TravelLogDTO;
+import org.scoula.domain.transaction.TransactionVO;
 import org.scoula.domain.travel.TravelLogVO;
 import org.scoula.external.s3.S3Service;
 import org.scoula.mapper.travel.TravelLogMapper;
+import org.scoula.service.transaction.TransactionService;
 import org.scoula.service.user.UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +27,7 @@ public class TravelLogService {
 	private final TravelLogMapper travelLogMapper;
 	private final UserService userService;
 	private final S3Service s3Service;
+	private final TransactionService transactionService;
 
 	//    public List<TravelLogDTO> getTravelLogs(final Long userId) {
 	//        userService.validateUserExists(userId);
@@ -67,6 +73,42 @@ public class TravelLogService {
 			.build();
 
 		travelLogMapper.save(travelLog);
+	}
+
+	/***
+	 * 여행 기간동안의 거래 내역 조회
+	 * 1. 여행 기간동안의 거래 내역 전체 조회
+	 * 2. 전체 여행 기간동안의  지출 총 합계와, 오늘의 거래 일자로 데이터 조회
+	 * @param userId
+	 * @param travelId
+	 * @return TravelLogTransactionListDTO
+	 */
+	public TravelLogTransactionListDTO getTravelTransactions(final Long userId, final Long travelId) {
+
+		TravelLogVO travelLog = travelLogMapper.findByTravelId(travelId);
+		List<TransactionVO> transactions = transactionService.getUserExpenseTransactions(userId,
+			travelLog.getAccountId(), travelLog.getTravelBeginDate(), travelLog.getTravelEndDate());
+
+		Long totalAmount = calculateTotalAmount(transactions);
+		Long todayAmount = calculateTodayAmount(transactions);
+
+		return new TravelLogTransactionListDTO(
+			travelId,
+			todayAmount,
+			totalAmount,
+			transactions.stream().map(TravelLogTransactionDTO::from).toList());
+	}
+
+	private Long calculateTotalAmount(List<TransactionVO> transactions) {
+		return transactions.stream().mapToLong(TransactionVO::getAmount).sum();
+	}
+
+	private Long calculateTodayAmount(List<TransactionVO> transactions) {
+		LocalDate today = LocalDate.now();
+		return transactions.stream()
+			.filter(t -> t.getCreatedAt().toLocalDate().equals(today))
+			.mapToLong(TransactionVO::getAmount)
+			.sum();
 	}
 
 }

--- a/trippy-server/src/main/resources/org/scoula/mapper/transaction/TransactionMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/transaction/TransactionMapper.xml
@@ -82,4 +82,10 @@
         ORDER BY created_at DESC
     </select>
 
+    <select id="findByTransactionId" resultMap="transactionMap">
+        SELECT *
+        FROM transaction
+        WHERE transaction_id = #{transactionId}
+    </select>
+
 </mapper>

--- a/trippy-server/src/main/resources/org/scoula/mapper/transaction/TransactionMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/transaction/TransactionMapper.xml
@@ -71,4 +71,15 @@
         VALUES (#{accountId}, #{userId}, #{transactionType}, #{amount}, #{title}, #{category}, #{latitude}, #{longitude}, #{balanceAfter}, #{status}, #{currencyCode}, NOW(), NOW())
     </insert>
 
+    <select id="findExpenseTransactionsByAccountId" resultMap="transactionMap">
+        SELECT *
+        FROM transaction
+        WHERE user_id = #{userId}
+          AND account_id = #{accountId}
+          AND created_at BETWEEN #{startDate} AND #{endDate}
+          AND transaction_type = 'WITHDRAW'  -- 지출만 조회
+          AND amount > 0  -- 양수 금액만 (지출)
+        ORDER BY created_at DESC
+    </select>
+
 </mapper>

--- a/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelLogMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/travel/TravelLogMapper.xml
@@ -7,6 +7,7 @@
     <resultMap id="travelLogMap" type="org.scoula.domain.travel.TravelLogVO">
         <id property="travelId" column="travel_id"/>
         <result property="userId" column="user_id"/>
+        <result property="accountId" column="account_id"/>
         <result property="title" column="title"/>
         <result property="travelBeginDate" column="travel_begin_date"/>
         <result property="travelEndDate" column="travel_end_date"/>
@@ -50,6 +51,12 @@
                    NOW(), NOW()
                )
     </insert>
+
+    <select id="findByTravelId" resultMap="travelLogMap">
+        SELECT *
+        FROM travel_log
+        WHERE travel_id = #{travelId}
+    </select>
 
 
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #76 

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
2h/10m

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
<img width="460" height="261" alt="스크린샷 2025-08-12 오후 4 09 29" src="https://github.com/user-attachments/assets/bd6342c2-ce66-49ac-ba92-0e3e07c639fa" />

### 이전 전체 조회에서 transactionId 받아오는걸로 조회합니다
### 근데 라우터가 {travelId}/{transactionId} 이 순서가 RestFul한거 같아서 travelId를 받긴 하지만 로직엔 전혀 연관 없습니다.
### 사실 travelId로 시작날짜, 끝나는 날짜 안에 transactionId가 있는지 확인 받아야하는데.... 에러 분기 처리 끝도 없을거 같아서 안했습니다...


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
