### PR TITLE
[fix] 계좌목록 조회 API 쿼리문 수정

### DIFF
--- a/trippy-server/src/main/java/org/scoula/controller/exchange/dto/response/ExchangeChangeRateDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/exchange/dto/response/ExchangeChangeRateDTO.java
@@ -5,6 +5,7 @@ public record ExchangeChangeRateDTO(
 	Double todayExchangeRate,
 	String upOrDown,
 	Double changeAmount,
-	Double changePercentage
+	Double changePercentage,
+	String currencyCode
 ) {
 }

--- a/trippy-server/src/main/java/org/scoula/service/exchange/ExchangeRateService.java
+++ b/trippy-server/src/main/java/org/scoula/service/exchange/ExchangeRateService.java
@@ -144,7 +144,8 @@ public class ExchangeRateService {
 			todayData.getBaseExchangeRate(),
 			upOrDown,
 			roundedChangeAmount,
-			roundedChangePercentage
+			roundedChangePercentage,
+			todayData.getCurrencyCode()
 		);
 	}
 }

--- a/trippy-server/src/main/resources/org/scoula/mapper/exchange/ExchangeRateMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/exchange/ExchangeRateMapper.xml
@@ -91,7 +91,7 @@
         where user_id = #{userId}
           and is_deleted = 'N'
           and account_currency = 'KRW'
-        and account_type = 'PERSON'
+        and account_type = 'person'
     </select>
 
     <select id="findTodayRateByCurrencyCode" resultMap="exchangeRateMap">

--- a/trippy-server/src/main/resources/org/scoula/mapper/exchange/ExchangeRateMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/exchange/ExchangeRateMapper.xml
@@ -90,7 +90,8 @@
         from account
         where user_id = #{userId}
           and is_deleted = 'N'
-          and account_currency = 'KOR'
+          and account_currency = 'KRW'
+        and account_type = 'PERSON'
     </select>
 
     <select id="findTodayRateByCurrencyCode" resultMap="exchangeRateMap">


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #132 

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
5분/5분

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->

- 환전을 위한 계좌목록 조회 시, 모임계좌를 걸러내고 DB상의 통화코드와 매치하기 위해 쿼리문을 다음과 같이 수정함.
- 기존 'KOR'에서 'KRW'로 변경
- 모임계좌를 걸러내기 위해 account_type 조건 추가

```    
<select id="getAccountList" resultMap="accountMap">
        select *
        from account
        where user_id = #{userId}
          and is_deleted = 'N'
          and account_currency = 'KRW'
        and account_type = 'person'
    </select>
```

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
