### PR TITLE
[FEAT] 디스코드 에러 로깅 (#4)

### DIFF
--- a/trippy-server/src/main/java/org/scoula/common/exception/DiscordNotificationService.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/DiscordNotificationService.java
@@ -1,9 +1,12 @@
 package org.scoula.common.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import okhttp3.*;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -11,9 +14,14 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PreDestroy;
 
 @Service
 @Log4j2
+@RequiredArgsConstructor
 public class DiscordNotificationService {
 
     @Value("${logging.discord.500.webhook-uri}")
@@ -22,40 +30,44 @@ public class DiscordNotificationService {
     @Value("${logging.discord.400.webhook-uri}")
     private String webhook4xxUrl;
 
-    private final OkHttpClient client = new OkHttpClient();
+    private final OkHttpClient client;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     // 500 에러용 (기존)
-    public void sendErrorNotification(String errorMessage, String stackTrace, String requestInfo) {
+    @Async("discordExecutor")
+    public void send5xxNotification(String errorMessage, String stackTrace, String requestInfo) {
         try {
-            String message = createErrorMessage(errorMessage, stackTrace, requestInfo);
-            sendToDiscord(message, webhook5xxUrl, "🚨 서버 에러 발생 🚨");
+            String message = create5xxMessage(errorMessage, stackTrace, requestInfo);
+            sendToDiscordAsync(message, webhook5xxUrl, "🚨 서버 에러 발생 🚨");
         } catch (Exception e) {
             log.error("Discord 알림 전송 실패: {}", e.getMessage(), e);
         }
     }
 
     // 400대 에러용 (새로 추가)
-    public void send4xxNotification(String errorMessage, String requestInfo, String clientInfo) {
+    @Async("discordExecutor")
+    public void send4xxNotification(String errorMessage, String requestInfo) {
         try {
             if (webhook4xxUrl == null || webhook4xxUrl.isEmpty()) {
                 log.debug("400대 에러 웹훅 URL이 설정되지 않음");
                 return;
             }
 
-            String message = create4xxMessage(errorMessage, requestInfo, clientInfo);
-            sendToDiscord(message, webhook4xxUrl, "👻 클라이언트 에러 발생 👻");
+            String message = create4xxMessage(errorMessage, requestInfo);
+            sendToDiscordAsync(message, webhook4xxUrl, "👻 클라이언트 에러 발생 👻");
         } catch (Exception e) {
             log.error("Discord 4xx 알림 전송 실패: {}", e.getMessage(), e);
         }
     }
 
-    private String create4xxMessage(String errorMessage, String requestInfo, String clientInfo) {
+    private String create4xxMessage(String errorMessage, String requestInfo) {
         StringBuilder message = new StringBuilder();
-        message.append("**에러 발생 시간:** ").append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))).append("\n");
-        message.append("**에러 메시지:** ").append(errorMessage != null ? errorMessage : "Unknown Error").append("\n");
+        message.append("**에러 발생 시간:** ")
+            .append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+            .append("\n");
+        message.append("**에러 메시지:** ").append(nz(errorMessage, "Unknown Error")).append("\n");
 
-        if (requestInfo != null && !requestInfo.isEmpty()) {
+        if (nz(requestInfo, "").contains(" ")) {
             String[] parts = requestInfo.split(" ");
             if (parts.length >= 2) {
                 String method = parts[0];
@@ -65,58 +77,77 @@ public class DiscordNotificationService {
             }
         }
 
-        if (clientInfo != null && !clientInfo.isEmpty()) {
-            message.append("**클라이언트 정보:** ").append(clientInfo).append("\n");
-        }
-
         return message.toString();
     }
 
 
-    private String createErrorMessage(String errorMessage, String stackTrace, String requestInfo) {
+    private String create5xxMessage(String errorMessage, String stackTrace, String requestInfo) {
         StringBuilder message = new StringBuilder();
-        message.append("**에러 발생 시간:** ").append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))).append("\n");
-        message.append("**에러 메시지:** ").append(errorMessage != null ? errorMessage : "Unknown Error").append("\n");
+        message.append("**에러 발생 시간:** ")
+            .append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+            .append("\n");
+        message.append("**에러 메시지:** ").append(nz(errorMessage, "Unknown Error")).append("\n");
 
-        if (requestInfo != null && !requestInfo.isEmpty()) {
-            // URI와 Method만 추출
+        if (nz(requestInfo, "").contains(" ")) {
             String[] parts = requestInfo.split(" ");
             if (parts.length >= 2) {
-                String method = parts[3];  // GET, POST 등
-                String uri = parts[1];     // /api/accounts 등
+                String method = parts[0];
+                String uri = parts[1];
                 message.append("**요청 메소드:** ").append(method).append("\n");
                 message.append("**요청 URI:** ").append(uri).append("\n");
             }
         }
-        
+
         message.append("```\n");
-        message.append(stackTrace != null ? (stackTrace.length() > 1000 ? stackTrace.substring(0, 1000) + "..." : stackTrace) : "No stack trace available");
-        message.append("\n```");
-        
+        String st = (stackTrace == null) ? "No stack trace available"
+            : (stackTrace.length() > 1800 ? stackTrace.substring(0, 1800) + "..." : stackTrace);
+        message.append(st).append("\n```");
         return message.toString();
     }
 
-    private void sendToDiscord(String message, String webhookUrl, String title) throws IOException {
+
+    private void sendToDiscordAsync(String message, String webhookUrl, String title) throws IOException {
         Map<String, Object> payload = new HashMap<>();
         payload.put("content", message);
         payload.put("username", title);
 
         String json = objectMapper.writeValueAsString(payload);
 
-        RequestBody body = RequestBody.create(
-            json,
-            MediaType.get("application/json; charset=utf-8")
-        );
+        RequestBody body = RequestBody.create(json, MediaType.get("application/json; charset=utf-8"));
+        Request request = new Request.Builder().url(webhookUrl).post(body).build();
 
-        Request request = new Request.Builder()
-            .url(webhookUrl)
-            .post(body)
-            .build();
-
-        try (Response response = client.newCall(request).execute()) {
-            if (!response.isSuccessful()) {
-                log.error("Discord 웹훅 전송 실패. 응답 코드: {}", response.code());
+        client.newCall(request).enqueue(new Callback() {
+            @Override public void onFailure(Call call, IOException e) {
+                log.error("Discord 웹훅 전송 실패: {}", e.getMessage());
             }
+            @Override public void onResponse(Call call, Response response) {
+                try (response) {
+                    if (!response.isSuccessful()) {
+                        log.error("Discord 웹훅 응답 실패: code={}", response.code());
+                    }
+                }
+            }
+        });
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        try {
+            client.dispatcher().cancelAll(); //모든 호출 취소
+            client.connectionPool().evictAll(); // 커넥션 풀 비우기
+            ExecutorService es = client.dispatcher().executorService(); //실행기 정상 종료 시도
+            es.shutdown();
+            if (!es.awaitTermination(5, TimeUnit.SECONDS)) {
+                es.shutdownNow(); // 강제 종료
+            }
+
+            if (client.cache() != null) client.cache().close();
+
+            log.info("OkHttp 리소스 정리 완료");
+        } catch (Exception e) {
+            log.warn("OkHttp 리소스 정리 중 예외: {}", e.getMessage());
         }
     }
+
+    private static String nz(String v, String d) { return (v == null || v.isEmpty()) ? d : v; }
 }

--- a/trippy-server/src/main/java/org/scoula/common/exception/DiscordNotificationService.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/DiscordNotificationService.java
@@ -1,0 +1,122 @@
+package org.scoula.common.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.log4j.Log4j2;
+import okhttp3.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@Log4j2
+public class DiscordNotificationService {
+
+    @Value("${logging.discord.500.webhook-uri}")
+    private String webhook5xxUrl;
+
+    @Value("${logging.discord.400.webhook-uri}")
+    private String webhook4xxUrl;
+
+    private final OkHttpClient client = new OkHttpClient();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 500 에러용 (기존)
+    public void sendErrorNotification(String errorMessage, String stackTrace, String requestInfo) {
+        try {
+            String message = createErrorMessage(errorMessage, stackTrace, requestInfo);
+            sendToDiscord(message, webhook5xxUrl, "🚨 서버 에러 발생 🚨");
+        } catch (Exception e) {
+            log.error("Discord 알림 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    // 400대 에러용 (새로 추가)
+    public void send4xxNotification(String errorMessage, String requestInfo, String clientInfo) {
+        try {
+            if (webhook4xxUrl == null || webhook4xxUrl.isEmpty()) {
+                log.debug("400대 에러 웹훅 URL이 설정되지 않음");
+                return;
+            }
+
+            String message = create4xxMessage(errorMessage, requestInfo, clientInfo);
+            sendToDiscord(message, webhook4xxUrl, "👻 클라이언트 에러 발생 👻");
+        } catch (Exception e) {
+            log.error("Discord 4xx 알림 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    private String create4xxMessage(String errorMessage, String requestInfo, String clientInfo) {
+        StringBuilder message = new StringBuilder();
+        message.append("**에러 발생 시간:** ").append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))).append("\n");
+        message.append("**에러 메시지:** ").append(errorMessage != null ? errorMessage : "Unknown Error").append("\n");
+
+        if (requestInfo != null && !requestInfo.isEmpty()) {
+            String[] parts = requestInfo.split(" ");
+            if (parts.length >= 2) {
+                String method = parts[0];
+                String uri = parts[1];
+                message.append("**요청 메소드:** ").append(method).append("\n");
+                message.append("**요청 URI:** ").append(uri).append("\n");
+            }
+        }
+
+        if (clientInfo != null && !clientInfo.isEmpty()) {
+            message.append("**클라이언트 정보:** ").append(clientInfo).append("\n");
+        }
+
+        return message.toString();
+    }
+
+
+    private String createErrorMessage(String errorMessage, String stackTrace, String requestInfo) {
+        StringBuilder message = new StringBuilder();
+        message.append("**에러 발생 시간:** ").append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))).append("\n");
+        message.append("**에러 메시지:** ").append(errorMessage != null ? errorMessage : "Unknown Error").append("\n");
+
+        if (requestInfo != null && !requestInfo.isEmpty()) {
+            // URI와 Method만 추출
+            String[] parts = requestInfo.split(" ");
+            if (parts.length >= 2) {
+                String method = parts[3];  // GET, POST 등
+                String uri = parts[1];     // /api/accounts 등
+                message.append("**요청 메소드:** ").append(method).append("\n");
+                message.append("**요청 URI:** ").append(uri).append("\n");
+            }
+        }
+        
+        message.append("```\n");
+        message.append(stackTrace != null ? (stackTrace.length() > 1000 ? stackTrace.substring(0, 1000) + "..." : stackTrace) : "No stack trace available");
+        message.append("\n```");
+        
+        return message.toString();
+    }
+
+    private void sendToDiscord(String message, String webhookUrl, String title) throws IOException {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("content", message);
+        payload.put("username", title);
+
+        String json = objectMapper.writeValueAsString(payload);
+
+        RequestBody body = RequestBody.create(
+            json,
+            MediaType.get("application/json; charset=utf-8")
+        );
+
+        Request request = new Request.Builder()
+            .url(webhookUrl)
+            .post(body)
+            .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                log.error("Discord 웹훅 전송 실패. 응답 코드: {}", response.code());
+            }
+        }
+    }
+}

--- a/trippy-server/src/main/java/org/scoula/common/exception/GlobalExceptionHandler.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/GlobalExceptionHandler.java
@@ -1,37 +1,196 @@
 package org.scoula.common.exception;
 
 import org.scoula.common.dto.ErrorResponse;
+import org.scoula.common.exception.model.ServerErrorException;
 import org.scoula.common.exception.model.TrippyException;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import lombok.extern.log4j.Log4j2;
+
+import javax.servlet.http.HttpServletRequest;
 
 @RestControllerAdvice
 @Log4j2
 public class GlobalExceptionHandler {
 
-	@ExceptionHandler(TrippyException.class)
-	public ResponseEntity<ErrorResponse> handleTrippyException(TrippyException ex) {
-		// 로그 추가
-		log.error("TrippyException 발생: {}", ex.getMessage(), ex);
+	@Autowired
+	private DiscordNotificationService discordNotificationService;
+
+	// ServerErrorException만 500 에러로 처리 (Discord 500 채널)
+	@ExceptionHandler(ServerErrorException.class)
+	public ResponseEntity<ErrorResponse> handleServerErrorException(ServerErrorException ex, HttpServletRequest request) {
+		log.error("=== 500 ServerErrorException 발생 ===");
+		log.error("에러 타입: {}", ex.getClass().getSimpleName());
+		log.error("에러 메시지: {}", ex.getMessage());
+		log.error("스택트레이스: ", ex);
+
+		// 요청 정보 수집
+		String requestInfo = String.format("%s %s",
+			request.getMethod(),
+			request.getRequestURI());
+
+		// 스택 트레이스를 문자열로 변환
+		java.io.StringWriter sw = new java.io.StringWriter();
+		java.io.PrintWriter pw = new java.io.PrintWriter(sw);
+		ex.printStackTrace(pw);
+		String stackTrace = sw.toString();
+
+		// 500 에러 Discord 알림 발송
+		send500Notification(ex.getMessage(), stackTrace, requestInfo);
 
 		return ResponseEntity
 			.status(ex.getErrorCode().getHttpStatus())
 			.body(ErrorResponse.error(ex.getErrorCode()));
 	}
 
-	// 일반 예외 처리
+	// 나머지 TrippyException들은 400대 에러로 처리 (Discord 400 채널)
+	@ExceptionHandler(TrippyException.class)
+	public ResponseEntity<ErrorResponse> handleTrippyException(TrippyException ex, HttpServletRequest request) {
+		log.warn("=== 400대 TrippyException 발생 ===");
+		log.warn("에러 타입: {}", ex.getClass().getSimpleName());
+		log.warn("에러 메시지: {}", ex.getMessage());
+		log.warn("에러 코드: {}", ex.getErrorCode());
+
+		// 요청 정보 수집
+		String requestInfo = String.format("%s %s",
+			request.getMethod(),
+			request.getRequestURI());
+
+		// 클라이언트 정보 수집
+		String clientInfo = String.format("IP: %s, User-Agent: %s",
+			getClientIP(request),
+			request.getHeader("User-Agent"));
+
+		// 400대 에러 Discord 알림 발송
+		send400Notification(ex.getClass().getSimpleName() + ": " + ex.getMessage(), requestInfo, clientInfo);
+
+		return ResponseEntity
+			.status(ex.getErrorCode().getHttpStatus())
+			.body(ErrorResponse.error(ex.getErrorCode()));
+	}
+
+	// 404 에러 처리 (Discord 400 채널)
+	@ExceptionHandler(NoHandlerFoundException.class)
+	public ResponseEntity<ErrorResponse> handleNotFound(NoHandlerFoundException ex, HttpServletRequest request) {
+
+		//아래와 같은 경우는 디코 로깅 안되도록
+		String uri = request.getRequestURI();
+		if ("/csrf".equals(uri) || "/".equals(uri)) {
+			return ResponseEntity.notFound().build();
+		}
+
+		// 상세 로깅
+		log.warn("=== 4XX 에러 상세 정보 ===");
+		log.warn("요청 URI: {}", request.getRequestURI());
+		log.warn("요청 Method: {}", request.getMethod());
+		log.warn("User-Agent: {}", request.getHeader("User-Agent"));
+		log.warn("Referer: {}", request.getHeader("Referer"));
+		log.warn("Remote IP: {}", getClientIP(request));
+		log.warn("Query String: {}", request.getQueryString());
+		log.warn("================================");
+
+		// 400대 에러 Discord 알림
+		String requestInfo = String.format("%s %s", request.getMethod(), request.getRequestURI());
+		String clientInfo = String.format("IP: %s, User-Agent: %s",
+			getClientIP(request),
+			request.getHeader("User-Agent"));
+
+		send400Notification("404 Not Found: " + request.getRequestURI(), requestInfo, clientInfo);
+
+		return ResponseEntity.notFound().build();
+	}
+
+	// Spring에서 자동으로 던지는 400대 에러들 처리
+	@ExceptionHandler({
+		HttpMessageNotReadableException.class,           // JSON 파싱 실패
+		MethodArgumentNotValidException.class,           // @Valid 검증 실패
+		MissingServletRequestParameterException.class,   // 필수 파라미터 누락
+		HttpRequestMethodNotSupportedException.class,    // 잘못된 HTTP 메서드
+		HttpMediaTypeNotSupportedException.class,        // 잘못된 Content-Type
+		TypeMismatchException.class                      // 타입 변환 실패
+	})
+	public ResponseEntity<ErrorResponse> handleSpringBadRequest(Exception ex, HttpServletRequest request) {
+		log.warn("=== Spring 400대 에러 발생 ===");
+		log.warn("에러 타입: {}", ex.getClass().getSimpleName());
+		log.warn("에러 메시지: {}", ex.getMessage());
+
+		String requestInfo = String.format("%s %s", request.getMethod(), request.getRequestURI());
+		String clientInfo = String.format("IP: %s, User-Agent: %s",
+			getClientIP(request),
+			request.getHeader("User-Agent"));
+
+		send400Notification(ex.getClass().getSimpleName() + ": " + ex.getMessage(), requestInfo, clientInfo);
+
+		return ResponseEntity
+			.badRequest()
+			.body(ErrorResponse.badRequestError("잘못된 요청입니다."));
+	}
+
+	// 일반 예외 처리 (500 에러 - Discord 500 채널)
 	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {
-		log.error("=== 500서버 에러 발생 ===");
+	public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex, HttpServletRequest request) {
+		log.error("=== 500 일반 예외 발생 ===");
 		log.error("에러 타입: {}", ex.getClass().getSimpleName());
 		log.error("에러 메시지: {}", ex.getMessage());
 		log.error("스택트레이스: ", ex);
 
+		// 요청 정보 수집
+		String requestInfo = String.format("%s %s",
+			request.getMethod(),
+			request.getRequestURI());
+
+		// 스택 트레이스를 문자열로 변환
+		java.io.StringWriter sw = new java.io.StringWriter();
+		java.io.PrintWriter pw = new java.io.PrintWriter(sw);
+		ex.printStackTrace(pw);
+		String stackTrace = sw.toString();
+
+		// 500 에러 Discord 알림 발송
+		send500Notification(ex.getMessage(), stackTrace, requestInfo);
+
 		return ResponseEntity
 			.internalServerError()
 			.body(ErrorResponse.badRequestError("서버 내부 오류가 발생했습니다."));
+	}
+
+	// 500 에러 Discord 알림 전송
+	private void send500Notification(String errorMessage, String stackTrace, String requestInfo) {
+		new Thread(() -> {
+			try {
+				discordNotificationService.sendErrorNotification(errorMessage, stackTrace, requestInfo);
+			} catch (Exception discordEx) {
+				log.error("Discord 500 알림 전송 중 에러 발생: {}", discordEx.getMessage());
+			}
+		}).start();
+	}
+
+	// 400대 에러 Discord 알림 전송
+	private void send400Notification(String errorMessage, String requestInfo, String clientInfo) {
+		new Thread(() -> {
+			try {
+				discordNotificationService.send4xxNotification(errorMessage, requestInfo, clientInfo);
+			} catch (Exception discordEx) {
+				log.error("Discord 400 알림 전송 중 에러 발생: {}", discordEx.getMessage());
+			}
+		}).start();
+	}
+
+	// 클라이언트 IP 추출
+	private String getClientIP(HttpServletRequest request) {
+		String xfHeader = request.getHeader("X-Forwarded-For");
+		if (xfHeader == null) {
+			return request.getRemoteAddr();
+		}
+		return xfHeader.split(",")[0];
 	}
 }

--- a/trippy-server/src/main/java/org/scoula/common/exception/GlobalExceptionHandler.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/GlobalExceptionHandler.java
@@ -53,7 +53,7 @@ public class GlobalExceptionHandler {
 			.body(ErrorResponse.error(ex.getErrorCode()));
 	}
 
-	// 나머지 TrippyException들은 400대 에러로 처리 (Discord 400 채널)
+	// 나머지 TrippyException들은 400대 에러로 처리
 	@ExceptionHandler(TrippyException.class)
 	public ResponseEntity<ErrorResponse> handleTrippyException(TrippyException ex, HttpServletRequest request) {
 		log.warn("=== 400대 TrippyException 발생 ===");
@@ -66,20 +66,15 @@ public class GlobalExceptionHandler {
 			request.getMethod(),
 			request.getRequestURI());
 
-		// 클라이언트 정보 수집
-		String clientInfo = String.format("IP: %s, User-Agent: %s",
-			getClientIP(request),
-			request.getHeader("User-Agent"));
-
 		// 400대 에러 Discord 알림 발송
-		send400Notification(ex.getClass().getSimpleName() + ": " + ex.getMessage(), requestInfo, clientInfo);
+		send400Notification(ex.getClass().getSimpleName() + ": " + ex.getMessage(), requestInfo);
 
 		return ResponseEntity
 			.status(ex.getErrorCode().getHttpStatus())
 			.body(ErrorResponse.error(ex.getErrorCode()));
 	}
 
-	// 404 에러 처리 (Discord 400 채널)
+	// 404 에러 처리
 	@ExceptionHandler(NoHandlerFoundException.class)
 	public ResponseEntity<ErrorResponse> handleNotFound(NoHandlerFoundException ex, HttpServletRequest request) {
 
@@ -93,19 +88,13 @@ public class GlobalExceptionHandler {
 		log.warn("=== 4XX 에러 상세 정보 ===");
 		log.warn("요청 URI: {}", request.getRequestURI());
 		log.warn("요청 Method: {}", request.getMethod());
-		log.warn("User-Agent: {}", request.getHeader("User-Agent"));
 		log.warn("Referer: {}", request.getHeader("Referer"));
-		log.warn("Remote IP: {}", getClientIP(request));
 		log.warn("Query String: {}", request.getQueryString());
 		log.warn("================================");
 
 		// 400대 에러 Discord 알림
 		String requestInfo = String.format("%s %s", request.getMethod(), request.getRequestURI());
-		String clientInfo = String.format("IP: %s, User-Agent: %s",
-			getClientIP(request),
-			request.getHeader("User-Agent"));
-
-		send400Notification("404 Not Found: " + request.getRequestURI(), requestInfo, clientInfo);
+		send400Notification("404 Not Found: " + request.getRequestURI(), requestInfo);
 
 		return ResponseEntity.notFound().build();
 	}
@@ -123,13 +112,10 @@ public class GlobalExceptionHandler {
 		log.warn("=== Spring 400대 에러 발생 ===");
 		log.warn("에러 타입: {}", ex.getClass().getSimpleName());
 		log.warn("에러 메시지: {}", ex.getMessage());
+		log.warn("================================");
 
 		String requestInfo = String.format("%s %s", request.getMethod(), request.getRequestURI());
-		String clientInfo = String.format("IP: %s, User-Agent: %s",
-			getClientIP(request),
-			request.getHeader("User-Agent"));
-
-		send400Notification(ex.getClass().getSimpleName() + ": " + ex.getMessage(), requestInfo, clientInfo);
+		send400Notification(ex.getClass().getSimpleName() + ": " + ex.getMessage(), requestInfo);
 
 		return ResponseEntity
 			.badRequest()
@@ -165,32 +151,20 @@ public class GlobalExceptionHandler {
 
 	// 500 에러 Discord 알림 전송
 	private void send500Notification(String errorMessage, String stackTrace, String requestInfo) {
-		new Thread(() -> {
-			try {
-				discordNotificationService.sendErrorNotification(errorMessage, stackTrace, requestInfo);
-			} catch (Exception discordEx) {
-				log.error("Discord 500 알림 전송 중 에러 발생: {}", discordEx.getMessage());
-			}
-		}).start();
+		try {
+			discordNotificationService.send5xxNotification(errorMessage, stackTrace, requestInfo); // @Async
+		} catch (Exception discordEx) {
+			log.error("Discord 500 알림 전송 중 에러: {}", discordEx.getMessage());
+		}
 	}
 
 	// 400대 에러 Discord 알림 전송
-	private void send400Notification(String errorMessage, String requestInfo, String clientInfo) {
-		new Thread(() -> {
-			try {
-				discordNotificationService.send4xxNotification(errorMessage, requestInfo, clientInfo);
-			} catch (Exception discordEx) {
-				log.error("Discord 400 알림 전송 중 에러 발생: {}", discordEx.getMessage());
-			}
-		}).start();
+	private void send400Notification(String errorMessage, String requestInfo) {
+		try {
+			discordNotificationService.send4xxNotification(errorMessage, requestInfo); // @Async
+		} catch (Exception discordEx) {
+			log.error("Discord 400 알림 전송 중 에러: {}", discordEx.getMessage());
+		}
 	}
 
-	// 클라이언트 IP 추출
-	private String getClientIP(HttpServletRequest request) {
-		String xfHeader = request.getHeader("X-Forwarded-For");
-		if (xfHeader == null) {
-			return request.getRemoteAddr();
-		}
-		return xfHeader.split(",")[0];
-	}
 }

--- a/trippy-server/src/main/java/org/scoula/config/discord/AsyncConfig.java
+++ b/trippy-server/src/main/java/org/scoula/config/discord/AsyncConfig.java
@@ -1,0 +1,24 @@
+package org.scoula.config.discord;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+	@Bean(name = "discordExecutor")
+	public ThreadPoolTaskExecutor discordExecutor() {
+		ThreadPoolTaskExecutor ex = new ThreadPoolTaskExecutor();
+		ex.setCorePoolSize(2);
+		ex.setMaxPoolSize(4);
+		ex.setQueueCapacity(100);
+		ex.setThreadNamePrefix("discord-");
+		ex.setWaitForTasksToCompleteOnShutdown(true); // 종료시 대기
+		ex.setAwaitTerminationSeconds(5);
+		ex.initialize();
+		return ex;
+	}
+}

--- a/trippy-server/src/main/java/org/scoula/config/discord/HttpClientConfig.java
+++ b/trippy-server/src/main/java/org/scoula/config/discord/HttpClientConfig.java
@@ -1,0 +1,16 @@
+package org.scoula.config.discord;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import okhttp3.OkHttpClient;
+
+@Configuration
+public class HttpClientConfig {
+	@Bean
+	public OkHttpClient okHttpClient() {
+		return new OkHttpClient.Builder()
+			.retryOnConnectionFailure(true)
+			.build();
+	}
+}

--- a/trippy-server/src/main/java/org/scoula/controller/HomeController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/HomeController.java
@@ -1,0 +1,14 @@
+package org.scoula.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+@RestController
+public class HomeController {
+
+	@GetMapping("/")
+	public RedirectView redirectToSwagger() {
+		return new RedirectView("/swagger-ui.html");
+	}
+}

--- a/trippy-server/src/main/java/org/scoula/domain/account/AccountVO.java
+++ b/trippy-server/src/main/java/org/scoula/domain/account/AccountVO.java
@@ -30,33 +30,34 @@ public class AccountVO extends BaseTime {
 
 	public static AccountVO from(AccountRequestDTO request, Long userId) {
 		return new AccountVO(
-				userId,
-				request.accountId(),
-				request.accountName(),
-				request.accountType(),
-				userId,
-				request.balance(),
-				request.accountCurrency(),
-				request.isDeleted()
+			userId,
+			request.accountId(),
+			request.accountName(),
+			request.accountType(),
+			userId,
+			request.balance(),
+			request.accountCurrency(),
+			request.isDeleted()
 		);
 	}
 
 	public static AccountVO fromCodefResponse(Map<String, Object> codefAccount, Long userId) {
-		String balanceStr = (String) codefAccount.get("resAccountBalance");
+
+		String balanceStr = (String)codefAccount.get("resAccountBalance");
 		Long balance = 0L;
 		if (balanceStr != null && !balanceStr.isEmpty()) {
 			balance = Long.parseLong(balanceStr);
 		}
 
 		return new AccountVO(
-				userId,
-				(String) codefAccount.get("resAccount"),
-				(String) codefAccount.get("resAccountName"),
-				AccountType.person,
-				userId,
-				balance,
-				(String) codefAccount.get("resAccountCurrency"),
-				DeletedStatus.N
+			userId,
+			(String)codefAccount.get("resAccount"),
+			(String)codefAccount.get("resAccountName"),
+			AccountType.person,
+			userId,
+			balance,
+			(String)codefAccount.get("resAccountCurrency"),
+			DeletedStatus.N
 		);
 	}
 }

--- a/trippy-server/src/main/resources/log4j2.xml
+++ b/trippy-server/src/main/resources/log4j2.xml
@@ -5,10 +5,6 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%t] %-5level %c{1} - %m%n"/>
         </Console>
-
-        <File name="file" fileName="logs/app.log" append="true">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%t] %-5level %c{1} - %m%n"/>
-        </File>
     </Appenders>
 
     <Loggers>


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #4 

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
1h/3h

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
배포 url랑 클라 연결하면서 생기는 부분을 해결하기 위해 400대 에러도 hook을 걸어놨어요.. 알람이 어마무시할 수 있지만 배포한링크랑 확인하려면 400 에러를 훅 걸어놔야겠다고 생각했습니다 나중에는 없앨거에요!

### 400 hook에서는 아래와 같이
<img width="631" height="119" alt="스크린샷 2025-08-12 오후 8 19 51" src="https://github.com/user-attachments/assets/b58cf4e9-3770-446c-ab03-815191b219d5" />


### 500 hook에서는 아래와 같이 
<img width="519" height="428" alt="스크린샷 2025-08-12 오후 8 15 53" src="https://github.com/user-attachments/assets/945e7617-5eb5-4433-95f3-41280ab73992" />


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
REFACTOR 커밋 내용

1. Tomcat 메모리 누수 방지
- @PreDestroy에서 OkHttp의 쓰레드, 커넥션 풀, 캐시를 명시적으로 종료하기 때문에
서버 종료 시 Tomcat이 [OkHttp TaskRunner], [Okio Watchdog] 같은 백그라운드 쓰레드를 강제로 끊지 않아도 된다. 
- 이게 없으면 Tomcat이 쓰레드 중지 못해서 메모리 누수 유발 가능성에 대한 경고를 계속띄움

2. 비동기 처리 안정성
- @Async("discordExecutor")를 통해 Discord 전송 로직이 메인 요청 처리와 분리돼서 HTTP 응답 속도가 느려지지 않는다.
- 서버가 내려갈 때도 @PreDestroy에서 스레드 풀 종료를 처리하므로 남아있는 작업이 정리된다.