### PR TITLE
[FEAT] 전화번호 인증코드 발급 & 인증 확인 (#11)

### DIFF
--- a/trippy-server/src/main/java/org/scoula/common/exception/DiscordNotificationService.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/DiscordNotificationService.java
@@ -1,9 +1,12 @@
 package org.scoula.common.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import okhttp3.*;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -11,9 +14,14 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PreDestroy;
 
 @Service
 @Log4j2
+@RequiredArgsConstructor
 public class DiscordNotificationService {
 
     @Value("${logging.discord.500.webhook-uri}")
@@ -22,40 +30,44 @@ public class DiscordNotificationService {
     @Value("${logging.discord.400.webhook-uri}")
     private String webhook4xxUrl;
 
-    private final OkHttpClient client = new OkHttpClient();
+    private final OkHttpClient client;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     // 500 에러용 (기존)
-    public void sendErrorNotification(String errorMessage, String stackTrace, String requestInfo) {
+    @Async("discordExecutor")
+    public void send5xxNotification(String errorMessage, String stackTrace, String requestInfo) {
         try {
-            String message = createErrorMessage(errorMessage, stackTrace, requestInfo);
-            sendToDiscord(message, webhook5xxUrl, "🚨 서버 에러 발생 🚨");
+            String message = create5xxMessage(errorMessage, stackTrace, requestInfo);
+            sendToDiscordAsync(message, webhook5xxUrl, "🚨 서버 에러 발생 🚨");
         } catch (Exception e) {
             log.error("Discord 알림 전송 실패: {}", e.getMessage(), e);
         }
     }
 
     // 400대 에러용 (새로 추가)
-    public void send4xxNotification(String errorMessage, String requestInfo, String clientInfo) {
+    @Async("discordExecutor")
+    public void send4xxNotification(String errorMessage, String requestInfo) {
         try {
             if (webhook4xxUrl == null || webhook4xxUrl.isEmpty()) {
                 log.debug("400대 에러 웹훅 URL이 설정되지 않음");
                 return;
             }
 
-            String message = create4xxMessage(errorMessage, requestInfo, clientInfo);
-            sendToDiscord(message, webhook4xxUrl, "👻 클라이언트 에러 발생 👻");
+            String message = create4xxMessage(errorMessage, requestInfo);
+            sendToDiscordAsync(message, webhook4xxUrl, "👻 클라이언트 에러 발생 👻");
         } catch (Exception e) {
             log.error("Discord 4xx 알림 전송 실패: {}", e.getMessage(), e);
         }
     }
 
-    private String create4xxMessage(String errorMessage, String requestInfo, String clientInfo) {
+    private String create4xxMessage(String errorMessage, String requestInfo) {
         StringBuilder message = new StringBuilder();
-        message.append("**에러 발생 시간:** ").append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))).append("\n");
-        message.append("**에러 메시지:** ").append(errorMessage != null ? errorMessage : "Unknown Error").append("\n");
+        message.append("**에러 발생 시간:** ")
+            .append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+            .append("\n");
+        message.append("**에러 메시지:** ").append(nz(errorMessage, "Unknown Error")).append("\n");
 
-        if (requestInfo != null && !requestInfo.isEmpty()) {
+        if (nz(requestInfo, "").contains(" ")) {
             String[] parts = requestInfo.split(" ");
             if (parts.length >= 2) {
                 String method = parts[0];
@@ -65,58 +77,77 @@ public class DiscordNotificationService {
             }
         }
 
-        if (clientInfo != null && !clientInfo.isEmpty()) {
-            message.append("**클라이언트 정보:** ").append(clientInfo).append("\n");
-        }
-
         return message.toString();
     }
 
 
-    private String createErrorMessage(String errorMessage, String stackTrace, String requestInfo) {
+    private String create5xxMessage(String errorMessage, String stackTrace, String requestInfo) {
         StringBuilder message = new StringBuilder();
-        message.append("**에러 발생 시간:** ").append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))).append("\n");
-        message.append("**에러 메시지:** ").append(errorMessage != null ? errorMessage : "Unknown Error").append("\n");
+        message.append("**에러 발생 시간:** ")
+            .append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+            .append("\n");
+        message.append("**에러 메시지:** ").append(nz(errorMessage, "Unknown Error")).append("\n");
 
-        if (requestInfo != null && !requestInfo.isEmpty()) {
-            // URI와 Method만 추출
+        if (nz(requestInfo, "").contains(" ")) {
             String[] parts = requestInfo.split(" ");
             if (parts.length >= 2) {
-                String method = parts[3];  // GET, POST 등
-                String uri = parts[1];     // /api/accounts 등
+                String method = parts[0];
+                String uri = parts[1];
                 message.append("**요청 메소드:** ").append(method).append("\n");
                 message.append("**요청 URI:** ").append(uri).append("\n");
             }
         }
-        
+
         message.append("```\n");
-        message.append(stackTrace != null ? (stackTrace.length() > 1000 ? stackTrace.substring(0, 1000) + "..." : stackTrace) : "No stack trace available");
-        message.append("\n```");
-        
+        String st = (stackTrace == null) ? "No stack trace available"
+            : (stackTrace.length() > 1800 ? stackTrace.substring(0, 1800) + "..." : stackTrace);
+        message.append(st).append("\n```");
         return message.toString();
     }
 
-    private void sendToDiscord(String message, String webhookUrl, String title) throws IOException {
+
+    private void sendToDiscordAsync(String message, String webhookUrl, String title) throws IOException {
         Map<String, Object> payload = new HashMap<>();
         payload.put("content", message);
         payload.put("username", title);
 
         String json = objectMapper.writeValueAsString(payload);
 
-        RequestBody body = RequestBody.create(
-            json,
-            MediaType.get("application/json; charset=utf-8")
-        );
+        RequestBody body = RequestBody.create(json, MediaType.get("application/json; charset=utf-8"));
+        Request request = new Request.Builder().url(webhookUrl).post(body).build();
 
-        Request request = new Request.Builder()
-            .url(webhookUrl)
-            .post(body)
-            .build();
-
-        try (Response response = client.newCall(request).execute()) {
-            if (!response.isSuccessful()) {
-                log.error("Discord 웹훅 전송 실패. 응답 코드: {}", response.code());
+        client.newCall(request).enqueue(new Callback() {
+            @Override public void onFailure(Call call, IOException e) {
+                log.error("Discord 웹훅 전송 실패: {}", e.getMessage());
             }
+            @Override public void onResponse(Call call, Response response) {
+                try (response) {
+                    if (!response.isSuccessful()) {
+                        log.error("Discord 웹훅 응답 실패: code={}", response.code());
+                    }
+                }
+            }
+        });
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        try {
+            client.dispatcher().cancelAll(); //모든 호출 취소
+            client.connectionPool().evictAll(); // 커넥션 풀 비우기
+            ExecutorService es = client.dispatcher().executorService(); //실행기 정상 종료 시도
+            es.shutdown();
+            if (!es.awaitTermination(5, TimeUnit.SECONDS)) {
+                es.shutdownNow(); // 강제 종료
+            }
+
+            if (client.cache() != null) client.cache().close();
+
+            log.info("OkHttp 리소스 정리 완료");
+        } catch (Exception e) {
+            log.warn("OkHttp 리소스 정리 중 예외: {}", e.getMessage());
         }
     }
+
+    private static String nz(String v, String d) { return (v == null || v.isEmpty()) ? d : v; }
 }

--- a/trippy-server/src/main/java/org/scoula/common/exception/DiscordNotificationService.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/DiscordNotificationService.java
@@ -73,7 +73,7 @@ public class DiscordNotificationService {
                 String method = parts[0];
                 String uri = parts[1];
                 message.append("**요청 메소드:** ").append(method).append("\n");
-                message.append("**요청 URI:** ").append(uri).append("\n");
+                message.append("**요청 URI:** ").append(uri).append("\n").append("========================================");
             }
         }
 
@@ -94,7 +94,7 @@ public class DiscordNotificationService {
                 String method = parts[0];
                 String uri = parts[1];
                 message.append("**요청 메소드:** ").append(method).append("\n");
-                message.append("**요청 URI:** ").append(uri).append("\n");
+                message.append("**요청 URI:** ").append(uri).append("\n").append("========================================");
             }
         }
 

--- a/trippy-server/src/main/java/org/scoula/common/exception/DiscordNotificationService.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/DiscordNotificationService.java
@@ -1,0 +1,122 @@
+package org.scoula.common.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.log4j.Log4j2;
+import okhttp3.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@Log4j2
+public class DiscordNotificationService {
+
+    @Value("${logging.discord.500.webhook-uri}")
+    private String webhook5xxUrl;
+
+    @Value("${logging.discord.400.webhook-uri}")
+    private String webhook4xxUrl;
+
+    private final OkHttpClient client = new OkHttpClient();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 500 에러용 (기존)
+    public void sendErrorNotification(String errorMessage, String stackTrace, String requestInfo) {
+        try {
+            String message = createErrorMessage(errorMessage, stackTrace, requestInfo);
+            sendToDiscord(message, webhook5xxUrl, "🚨 서버 에러 발생 🚨");
+        } catch (Exception e) {
+            log.error("Discord 알림 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    // 400대 에러용 (새로 추가)
+    public void send4xxNotification(String errorMessage, String requestInfo, String clientInfo) {
+        try {
+            if (webhook4xxUrl == null || webhook4xxUrl.isEmpty()) {
+                log.debug("400대 에러 웹훅 URL이 설정되지 않음");
+                return;
+            }
+
+            String message = create4xxMessage(errorMessage, requestInfo, clientInfo);
+            sendToDiscord(message, webhook4xxUrl, "👻 클라이언트 에러 발생 👻");
+        } catch (Exception e) {
+            log.error("Discord 4xx 알림 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    private String create4xxMessage(String errorMessage, String requestInfo, String clientInfo) {
+        StringBuilder message = new StringBuilder();
+        message.append("**에러 발생 시간:** ").append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))).append("\n");
+        message.append("**에러 메시지:** ").append(errorMessage != null ? errorMessage : "Unknown Error").append("\n");
+
+        if (requestInfo != null && !requestInfo.isEmpty()) {
+            String[] parts = requestInfo.split(" ");
+            if (parts.length >= 2) {
+                String method = parts[0];
+                String uri = parts[1];
+                message.append("**요청 메소드:** ").append(method).append("\n");
+                message.append("**요청 URI:** ").append(uri).append("\n");
+            }
+        }
+
+        if (clientInfo != null && !clientInfo.isEmpty()) {
+            message.append("**클라이언트 정보:** ").append(clientInfo).append("\n");
+        }
+
+        return message.toString();
+    }
+
+
+    private String createErrorMessage(String errorMessage, String stackTrace, String requestInfo) {
+        StringBuilder message = new StringBuilder();
+        message.append("**에러 발생 시간:** ").append(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))).append("\n");
+        message.append("**에러 메시지:** ").append(errorMessage != null ? errorMessage : "Unknown Error").append("\n");
+
+        if (requestInfo != null && !requestInfo.isEmpty()) {
+            // URI와 Method만 추출
+            String[] parts = requestInfo.split(" ");
+            if (parts.length >= 2) {
+                String method = parts[3];  // GET, POST 등
+                String uri = parts[1];     // /api/accounts 등
+                message.append("**요청 메소드:** ").append(method).append("\n");
+                message.append("**요청 URI:** ").append(uri).append("\n");
+            }
+        }
+        
+        message.append("```\n");
+        message.append(stackTrace != null ? (stackTrace.length() > 1000 ? stackTrace.substring(0, 1000) + "..." : stackTrace) : "No stack trace available");
+        message.append("\n```");
+        
+        return message.toString();
+    }
+
+    private void sendToDiscord(String message, String webhookUrl, String title) throws IOException {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("content", message);
+        payload.put("username", title);
+
+        String json = objectMapper.writeValueAsString(payload);
+
+        RequestBody body = RequestBody.create(
+            json,
+            MediaType.get("application/json; charset=utf-8")
+        );
+
+        Request request = new Request.Builder()
+            .url(webhookUrl)
+            .post(body)
+            .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                log.error("Discord 웹훅 전송 실패. 응답 코드: {}", response.code());
+            }
+        }
+    }
+}

--- a/trippy-server/src/main/java/org/scoula/common/exception/GlobalExceptionHandler.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/GlobalExceptionHandler.java
@@ -1,37 +1,196 @@
 package org.scoula.common.exception;
 
 import org.scoula.common.dto.ErrorResponse;
+import org.scoula.common.exception.model.ServerErrorException;
 import org.scoula.common.exception.model.TrippyException;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import lombok.extern.log4j.Log4j2;
+
+import javax.servlet.http.HttpServletRequest;
 
 @RestControllerAdvice
 @Log4j2
 public class GlobalExceptionHandler {
 
-	@ExceptionHandler(TrippyException.class)
-	public ResponseEntity<ErrorResponse> handleTrippyException(TrippyException ex) {
-		// 로그 추가
-		log.error("TrippyException 발생: {}", ex.getMessage(), ex);
+	@Autowired
+	private DiscordNotificationService discordNotificationService;
+
+	// ServerErrorException만 500 에러로 처리 (Discord 500 채널)
+	@ExceptionHandler(ServerErrorException.class)
+	public ResponseEntity<ErrorResponse> handleServerErrorException(ServerErrorException ex, HttpServletRequest request) {
+		log.error("=== 500 ServerErrorException 발생 ===");
+		log.error("에러 타입: {}", ex.getClass().getSimpleName());
+		log.error("에러 메시지: {}", ex.getMessage());
+		log.error("스택트레이스: ", ex);
+
+		// 요청 정보 수집
+		String requestInfo = String.format("%s %s",
+			request.getMethod(),
+			request.getRequestURI());
+
+		// 스택 트레이스를 문자열로 변환
+		java.io.StringWriter sw = new java.io.StringWriter();
+		java.io.PrintWriter pw = new java.io.PrintWriter(sw);
+		ex.printStackTrace(pw);
+		String stackTrace = sw.toString();
+
+		// 500 에러 Discord 알림 발송
+		send500Notification(ex.getMessage(), stackTrace, requestInfo);
 
 		return ResponseEntity
 			.status(ex.getErrorCode().getHttpStatus())
 			.body(ErrorResponse.error(ex.getErrorCode()));
 	}
 
-	// 일반 예외 처리
+	// 나머지 TrippyException들은 400대 에러로 처리 (Discord 400 채널)
+	@ExceptionHandler(TrippyException.class)
+	public ResponseEntity<ErrorResponse> handleTrippyException(TrippyException ex, HttpServletRequest request) {
+		log.warn("=== 400대 TrippyException 발생 ===");
+		log.warn("에러 타입: {}", ex.getClass().getSimpleName());
+		log.warn("에러 메시지: {}", ex.getMessage());
+		log.warn("에러 코드: {}", ex.getErrorCode());
+
+		// 요청 정보 수집
+		String requestInfo = String.format("%s %s",
+			request.getMethod(),
+			request.getRequestURI());
+
+		// 클라이언트 정보 수집
+		String clientInfo = String.format("IP: %s, User-Agent: %s",
+			getClientIP(request),
+			request.getHeader("User-Agent"));
+
+		// 400대 에러 Discord 알림 발송
+		send400Notification(ex.getClass().getSimpleName() + ": " + ex.getMessage(), requestInfo, clientInfo);
+
+		return ResponseEntity
+			.status(ex.getErrorCode().getHttpStatus())
+			.body(ErrorResponse.error(ex.getErrorCode()));
+	}
+
+	// 404 에러 처리 (Discord 400 채널)
+	@ExceptionHandler(NoHandlerFoundException.class)
+	public ResponseEntity<ErrorResponse> handleNotFound(NoHandlerFoundException ex, HttpServletRequest request) {
+
+		//아래와 같은 경우는 디코 로깅 안되도록
+		String uri = request.getRequestURI();
+		if ("/csrf".equals(uri) || "/".equals(uri)) {
+			return ResponseEntity.notFound().build();
+		}
+
+		// 상세 로깅
+		log.warn("=== 4XX 에러 상세 정보 ===");
+		log.warn("요청 URI: {}", request.getRequestURI());
+		log.warn("요청 Method: {}", request.getMethod());
+		log.warn("User-Agent: {}", request.getHeader("User-Agent"));
+		log.warn("Referer: {}", request.getHeader("Referer"));
+		log.warn("Remote IP: {}", getClientIP(request));
+		log.warn("Query String: {}", request.getQueryString());
+		log.warn("================================");
+
+		// 400대 에러 Discord 알림
+		String requestInfo = String.format("%s %s", request.getMethod(), request.getRequestURI());
+		String clientInfo = String.format("IP: %s, User-Agent: %s",
+			getClientIP(request),
+			request.getHeader("User-Agent"));
+
+		send400Notification("404 Not Found: " + request.getRequestURI(), requestInfo, clientInfo);
+
+		return ResponseEntity.notFound().build();
+	}
+
+	// Spring에서 자동으로 던지는 400대 에러들 처리
+	@ExceptionHandler({
+		HttpMessageNotReadableException.class,           // JSON 파싱 실패
+		MethodArgumentNotValidException.class,           // @Valid 검증 실패
+		MissingServletRequestParameterException.class,   // 필수 파라미터 누락
+		HttpRequestMethodNotSupportedException.class,    // 잘못된 HTTP 메서드
+		HttpMediaTypeNotSupportedException.class,        // 잘못된 Content-Type
+		TypeMismatchException.class                      // 타입 변환 실패
+	})
+	public ResponseEntity<ErrorResponse> handleSpringBadRequest(Exception ex, HttpServletRequest request) {
+		log.warn("=== Spring 400대 에러 발생 ===");
+		log.warn("에러 타입: {}", ex.getClass().getSimpleName());
+		log.warn("에러 메시지: {}", ex.getMessage());
+
+		String requestInfo = String.format("%s %s", request.getMethod(), request.getRequestURI());
+		String clientInfo = String.format("IP: %s, User-Agent: %s",
+			getClientIP(request),
+			request.getHeader("User-Agent"));
+
+		send400Notification(ex.getClass().getSimpleName() + ": " + ex.getMessage(), requestInfo, clientInfo);
+
+		return ResponseEntity
+			.badRequest()
+			.body(ErrorResponse.badRequestError("잘못된 요청입니다."));
+	}
+
+	// 일반 예외 처리 (500 에러 - Discord 500 채널)
 	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {
-		log.error("=== 500서버 에러 발생 ===");
+	public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex, HttpServletRequest request) {
+		log.error("=== 500 일반 예외 발생 ===");
 		log.error("에러 타입: {}", ex.getClass().getSimpleName());
 		log.error("에러 메시지: {}", ex.getMessage());
 		log.error("스택트레이스: ", ex);
 
+		// 요청 정보 수집
+		String requestInfo = String.format("%s %s",
+			request.getMethod(),
+			request.getRequestURI());
+
+		// 스택 트레이스를 문자열로 변환
+		java.io.StringWriter sw = new java.io.StringWriter();
+		java.io.PrintWriter pw = new java.io.PrintWriter(sw);
+		ex.printStackTrace(pw);
+		String stackTrace = sw.toString();
+
+		// 500 에러 Discord 알림 발송
+		send500Notification(ex.getMessage(), stackTrace, requestInfo);
+
 		return ResponseEntity
 			.internalServerError()
 			.body(ErrorResponse.badRequestError("서버 내부 오류가 발생했습니다."));
+	}
+
+	// 500 에러 Discord 알림 전송
+	private void send500Notification(String errorMessage, String stackTrace, String requestInfo) {
+		new Thread(() -> {
+			try {
+				discordNotificationService.sendErrorNotification(errorMessage, stackTrace, requestInfo);
+			} catch (Exception discordEx) {
+				log.error("Discord 500 알림 전송 중 에러 발생: {}", discordEx.getMessage());
+			}
+		}).start();
+	}
+
+	// 400대 에러 Discord 알림 전송
+	private void send400Notification(String errorMessage, String requestInfo, String clientInfo) {
+		new Thread(() -> {
+			try {
+				discordNotificationService.send4xxNotification(errorMessage, requestInfo, clientInfo);
+			} catch (Exception discordEx) {
+				log.error("Discord 400 알림 전송 중 에러 발생: {}", discordEx.getMessage());
+			}
+		}).start();
+	}
+
+	// 클라이언트 IP 추출
+	private String getClientIP(HttpServletRequest request) {
+		String xfHeader = request.getHeader("X-Forwarded-For");
+		if (xfHeader == null) {
+			return request.getRemoteAddr();
+		}
+		return xfHeader.split(",")[0];
 	}
 }

--- a/trippy-server/src/main/java/org/scoula/common/exception/GlobalExceptionHandler.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/GlobalExceptionHandler.java
@@ -53,7 +53,7 @@ public class GlobalExceptionHandler {
 			.body(ErrorResponse.error(ex.getErrorCode()));
 	}
 
-	// 나머지 TrippyException들은 400대 에러로 처리 (Discord 400 채널)
+	// 나머지 TrippyException들은 400대 에러로 처리
 	@ExceptionHandler(TrippyException.class)
 	public ResponseEntity<ErrorResponse> handleTrippyException(TrippyException ex, HttpServletRequest request) {
 		log.warn("=== 400대 TrippyException 발생 ===");
@@ -66,20 +66,15 @@ public class GlobalExceptionHandler {
 			request.getMethod(),
 			request.getRequestURI());
 
-		// 클라이언트 정보 수집
-		String clientInfo = String.format("IP: %s, User-Agent: %s",
-			getClientIP(request),
-			request.getHeader("User-Agent"));
-
 		// 400대 에러 Discord 알림 발송
-		send400Notification(ex.getClass().getSimpleName() + ": " + ex.getMessage(), requestInfo, clientInfo);
+		send400Notification(ex.getClass().getSimpleName() + ": " + ex.getMessage(), requestInfo);
 
 		return ResponseEntity
 			.status(ex.getErrorCode().getHttpStatus())
 			.body(ErrorResponse.error(ex.getErrorCode()));
 	}
 
-	// 404 에러 처리 (Discord 400 채널)
+	// 404 에러 처리
 	@ExceptionHandler(NoHandlerFoundException.class)
 	public ResponseEntity<ErrorResponse> handleNotFound(NoHandlerFoundException ex, HttpServletRequest request) {
 
@@ -93,19 +88,13 @@ public class GlobalExceptionHandler {
 		log.warn("=== 4XX 에러 상세 정보 ===");
 		log.warn("요청 URI: {}", request.getRequestURI());
 		log.warn("요청 Method: {}", request.getMethod());
-		log.warn("User-Agent: {}", request.getHeader("User-Agent"));
 		log.warn("Referer: {}", request.getHeader("Referer"));
-		log.warn("Remote IP: {}", getClientIP(request));
 		log.warn("Query String: {}", request.getQueryString());
 		log.warn("================================");
 
 		// 400대 에러 Discord 알림
 		String requestInfo = String.format("%s %s", request.getMethod(), request.getRequestURI());
-		String clientInfo = String.format("IP: %s, User-Agent: %s",
-			getClientIP(request),
-			request.getHeader("User-Agent"));
-
-		send400Notification("404 Not Found: " + request.getRequestURI(), requestInfo, clientInfo);
+		send400Notification("404 Not Found: " + request.getRequestURI(), requestInfo);
 
 		return ResponseEntity.notFound().build();
 	}
@@ -123,13 +112,10 @@ public class GlobalExceptionHandler {
 		log.warn("=== Spring 400대 에러 발생 ===");
 		log.warn("에러 타입: {}", ex.getClass().getSimpleName());
 		log.warn("에러 메시지: {}", ex.getMessage());
+		log.warn("================================");
 
 		String requestInfo = String.format("%s %s", request.getMethod(), request.getRequestURI());
-		String clientInfo = String.format("IP: %s, User-Agent: %s",
-			getClientIP(request),
-			request.getHeader("User-Agent"));
-
-		send400Notification(ex.getClass().getSimpleName() + ": " + ex.getMessage(), requestInfo, clientInfo);
+		send400Notification(ex.getClass().getSimpleName() + ": " + ex.getMessage(), requestInfo);
 
 		return ResponseEntity
 			.badRequest()
@@ -165,32 +151,20 @@ public class GlobalExceptionHandler {
 
 	// 500 에러 Discord 알림 전송
 	private void send500Notification(String errorMessage, String stackTrace, String requestInfo) {
-		new Thread(() -> {
-			try {
-				discordNotificationService.sendErrorNotification(errorMessage, stackTrace, requestInfo);
-			} catch (Exception discordEx) {
-				log.error("Discord 500 알림 전송 중 에러 발생: {}", discordEx.getMessage());
-			}
-		}).start();
+		try {
+			discordNotificationService.send5xxNotification(errorMessage, stackTrace, requestInfo); // @Async
+		} catch (Exception discordEx) {
+			log.error("Discord 500 알림 전송 중 에러: {}", discordEx.getMessage());
+		}
 	}
 
 	// 400대 에러 Discord 알림 전송
-	private void send400Notification(String errorMessage, String requestInfo, String clientInfo) {
-		new Thread(() -> {
-			try {
-				discordNotificationService.send4xxNotification(errorMessage, requestInfo, clientInfo);
-			} catch (Exception discordEx) {
-				log.error("Discord 400 알림 전송 중 에러 발생: {}", discordEx.getMessage());
-			}
-		}).start();
+	private void send400Notification(String errorMessage, String requestInfo) {
+		try {
+			discordNotificationService.send4xxNotification(errorMessage, requestInfo); // @Async
+		} catch (Exception discordEx) {
+			log.error("Discord 400 알림 전송 중 에러: {}", discordEx.getMessage());
+		}
 	}
 
-	// 클라이언트 IP 추출
-	private String getClientIP(HttpServletRequest request) {
-		String xfHeader = request.getHeader("X-Forwarded-For");
-		if (xfHeader == null) {
-			return request.getRemoteAddr();
-		}
-		return xfHeader.split(",")[0];
-	}
 }

--- a/trippy-server/src/main/java/org/scoula/common/exception/enums/ErrorCode.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/enums/ErrorCode.java
@@ -11,6 +11,10 @@ public enum ErrorCode {
 	INVALID_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰을 입력했습니다."),
 	INVALID_REFRESH_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 리프레시 토큰을 입력했습니다."),
 	INVALID_TOKEN_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 토큰 타입입니다. Access Token을 사용해주세요."),
+	INVALID_PHONE_NUMBER_EXCEPTION(HttpStatus.BAD_REQUEST, "전화번호가 잘못되었습니다."),
+	NOT_MATCH_VERIFICATION_CODE_EXCEPTION(HttpStatus.BAD_REQUEST, "전화번호 인증 코드가 일치하지 않습니다."),
+	INVALID_PASSWORD_EXCEPTION(HttpStatus.BAD_REQUEST, "비밀번호가 잘못되었습니다."),
+
 	SIGHTSEEING_BAD_REQUEST_EXCEPTION(HttpStatus.BAD_REQUEST, "관광바우처 정보가 잘못되었습니다."),
 	INVALID_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
 	INVALID_INVITE_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 초대 링크입니다."),
@@ -18,8 +22,8 @@ public enum ErrorCode {
 	NOT_GROUP_ACCOUNT(HttpStatus.BAD_REQUEST, "모임계좌가 아닌 계좌입니다."),
 	ACCOUNT_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "해지된 계좌입니다."),
 	NOT_GROUP_ACCOUNT_LEADER_EXCEPTION(HttpStatus.BAD_REQUEST, "모임계좌 모임주가 아닌 사용자입니다."),
+
 	INVALID_RESIDENT_NUMBER_EXCEPTION(HttpStatus.BAD_REQUEST, "주민번호가 잘못되었습니다."),
-	INVALID_PASSWORD_EXCEPTION(HttpStatus.BAD_REQUEST, "비밀번호가 잘못되었습니다."),
 	TRAVEL_ID_REQUIRED(HttpStatus.BAD_REQUEST, "travelId는 필수입니다."),
 	TRAVEL_LOG_ACCOUNT_ID_EMPTY(HttpStatus.BAD_REQUEST, "travel_log.account_id가 비어 있습니다. travelId={0}"),
 
@@ -33,6 +37,7 @@ public enum ErrorCode {
 	CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카드입니다."),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
 	USER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 유저가 존재하지 않습니다."),
+	NOT_FOUND_VERIFICATION_CODE_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 전화번호 인증 코드입니다."),
 
 	CONNECTED_ID_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "connectedId를 찾을 수 없습니다."),
 

--- a/trippy-server/src/main/java/org/scoula/common/exception/enums/SuccessCode.java
+++ b/trippy-server/src/main/java/org/scoula/common/exception/enums/SuccessCode.java
@@ -12,6 +12,8 @@ public enum SuccessCode {
 	SIGNUP_SUCCESS(HttpStatus.OK, "회원가입 성공"),
 	CHECK_PASSWORD_SUCCESS(HttpStatus.OK, "비밀번호 확인 성공"),
 	GET_ALL_USERS_SUCCESS(HttpStatus.OK, "유저 토큰 전체 조회 성공"),
+	SEND_VERIFICATION_CODE_SUCCESS(HttpStatus.OK, "전화번호 인증 요청 성공"),
+	VERIFICATION_CODE_MATCH_SUCCESS(HttpStatus.OK, "전화번호 인증 성공"),
 
 	//알림
 	GET_ALL_NOTIS_SUCCESS(HttpStatus.OK, "알림 전체 조회 성공"),

--- a/trippy-server/src/main/java/org/scoula/common/util/SmsUtil.java
+++ b/trippy-server/src/main/java/org/scoula/common/util/SmsUtil.java
@@ -1,4 +1,42 @@
 package org.scoula.common.util;
 
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.scoula.external.sms.SmsService;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
 public class SmsUtil {
+	private static final String VERIFICATION_MESSAGE_FORM = "[%s] trippy에서 보낸 인증번호입니다.";
+	private static final int VERIFICATION_EXPIRE_TIME = 3;
+	private final SmsService smsService;
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public boolean sendVerificationCode(final String to, final String verificationCode) throws IOException {
+		final String verificationCodeMessage = String.format(VERIFICATION_MESSAGE_FORM, verificationCode);
+		return smsService.sendSms(to, verificationCodeMessage);
+	}
+
+	public void saveVerificationCode(final String to, final String verificationCode) {
+		redisTemplate.opsForValue().set(to, verificationCode, VERIFICATION_EXPIRE_TIME, TimeUnit.MINUTES);
+	}
+
+	public boolean isVerificationCode(final String to) {
+		return redisTemplate.opsForValue().get(to) != null;
+	}
+
+	public String getVerificationCode(final String to) {
+		return redisTemplate.opsForValue().get(to);
+	}
+
+	public void deleteVerificationCode(final String to) {
+		redisTemplate.delete(to);
+	}
+
 }
+

--- a/trippy-server/src/main/java/org/scoula/common/util/VerificationCodeGenerator.java
+++ b/trippy-server/src/main/java/org/scoula/common/util/VerificationCodeGenerator.java
@@ -1,4 +1,13 @@
 package org.scoula.common.util;
 
+import java.security.SecureRandom;
+
 public class VerificationCodeGenerator {
+	private static final SecureRandom secureRandom = new SecureRandom();
+	private static final int START_NUM = 100_000;
+	private static final int END_NUM = 999_999;
+
+	public static String generate() {
+		return String.valueOf(secureRandom.nextInt(START_NUM, END_NUM));
+	}
 }

--- a/trippy-server/src/main/java/org/scoula/config/discord/AsyncConfig.java
+++ b/trippy-server/src/main/java/org/scoula/config/discord/AsyncConfig.java
@@ -1,0 +1,24 @@
+package org.scoula.config.discord;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+	@Bean(name = "discordExecutor")
+	public ThreadPoolTaskExecutor discordExecutor() {
+		ThreadPoolTaskExecutor ex = new ThreadPoolTaskExecutor();
+		ex.setCorePoolSize(2);
+		ex.setMaxPoolSize(4);
+		ex.setQueueCapacity(100);
+		ex.setThreadNamePrefix("discord-");
+		ex.setWaitForTasksToCompleteOnShutdown(true); // 종료시 대기
+		ex.setAwaitTerminationSeconds(5);
+		ex.initialize();
+		return ex;
+	}
+}

--- a/trippy-server/src/main/java/org/scoula/config/discord/HttpClientConfig.java
+++ b/trippy-server/src/main/java/org/scoula/config/discord/HttpClientConfig.java
@@ -1,0 +1,16 @@
+package org.scoula.config.discord;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import okhttp3.OkHttpClient;
+
+@Configuration
+public class HttpClientConfig {
+	@Bean
+	public OkHttpClient okHttpClient() {
+		return new OkHttpClient.Builder()
+			.retryOnConnectionFailure(true)
+			.build();
+	}
+}

--- a/trippy-server/src/main/java/org/scoula/config/http/RestTemplateConfig.java
+++ b/trippy-server/src/main/java/org/scoula/config/http/RestTemplateConfig.java
@@ -1,0 +1,34 @@
+package org.scoula.config.http;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		// 커넥션 풀
+		PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
+		cm.setMaxTotal(100);             // 전체 커넥션 수
+		cm.setDefaultMaxPerRoute(50);    // 라우트당 최대
+
+		HttpClient httpClient = HttpClients.custom()
+			.setConnectionManager(cm)
+			.disableCookieManagement()
+			.build();
+
+		HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+		factory.setHttpClient(httpClient);
+		factory.setConnectTimeout(3000);   // 연결 타임아웃(ms)
+		factory.setReadTimeout(5000);      // 응답 대기 타임아웃(ms)
+		factory.setConnectionRequestTimeout(2000); // 풀에서 커넥션 빌림 대기
+
+		return new RestTemplate(factory);
+	}
+}

--- a/trippy-server/src/main/java/org/scoula/controller/HomeController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/HomeController.java
@@ -1,0 +1,14 @@
+package org.scoula.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+@RestController
+public class HomeController {
+
+	@GetMapping("/")
+	public RedirectView redirectToSwagger() {
+		return new RedirectView("/swagger-ui.html");
+	}
+}

--- a/trippy-server/src/main/java/org/scoula/controller/user/UserController.java
+++ b/trippy-server/src/main/java/org/scoula/controller/user/UserController.java
@@ -1,5 +1,6 @@
 package org.scoula.controller.user;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.scoula.common.dto.ErrorResponse;
@@ -8,6 +9,8 @@ import org.scoula.common.dto.SuccessResponse;
 import org.scoula.common.dto.TokenPair;
 import org.scoula.common.exception.enums.SuccessCode;
 import org.scoula.config.resolver.UserId;
+import org.scoula.controller.user.dto.request.PhoneNumberDTO;
+import org.scoula.controller.user.dto.request.VerifyCodeDTO;
 import org.scoula.controller.user.dto.response.AllUsersTokenDTO;
 import org.scoula.controller.user.dto.request.CheckPasswordDTO;
 import org.scoula.controller.user.dto.request.SignUpDTO;
@@ -45,6 +48,32 @@ public class UserController {
 	@PostMapping("/signup")
 	public SuccessResponse<TokenPair> signUp(@ApiParam(value = "회원가입 정보", required = true) @RequestBody SignUpDTO signUpDTO) {
 		return SuccessResponse.success(SuccessCode.SIGNUP_SUCCESS, userService.signUp(signUpDTO));
+	}
+
+	@ApiOperation(value = "인증번호 요청 API", notes = "인증번호를 요청하는 API입니다.")
+	@ApiResponses(value = {
+		@ApiResponse(code = 200, message = "전화번호 인증 요청 성공", response = SuccessResponse.class),
+		@ApiResponse(code = 400, message = "전화번호가 잘못되었습니다.", response = ErrorResponse.class),
+		@ApiResponse(code = 500, message = "서버 내부 오류입니다.", response = ErrorResponse.class)
+	})
+	@PostMapping("/phoneNumber")
+	public SuccessNonDataResponse sendVerificationCodeMessage(@ApiParam(value = "전화번호", required = true) @RequestBody PhoneNumberDTO phoneNumberDTO) throws IOException {
+		userService.sendVerificationCodeMessage(phoneNumberDTO.phoneNumber());
+		return SuccessNonDataResponse.success(SuccessCode.SEND_VERIFICATION_CODE_SUCCESS);
+	}
+
+	@ApiOperation(value = "전화번호 인증 API", notes = "전화번호를 인증하는 API입니다.")
+	@ApiResponses(value = {
+		@ApiResponse(code = 200, message = "전화번호 인증 성공", response = SuccessResponse.class),
+		@ApiResponse(code = 400, message = "인증번호가 일치하지 않습니다.", response = ErrorResponse.class),
+		@ApiResponse(code = 400, message = "인증번호가 만료되었습니다.", response = ErrorResponse.class),
+		@ApiResponse(code = 400, message = "인증번호가 존재하지 않습니다.", response = ErrorResponse.class),
+		@ApiResponse(code = 500, message = "서버 내부 오류입니다.", response = ErrorResponse.class)
+	})
+	@PostMapping("/phoneNumber/verify")
+	public SuccessNonDataResponse verifyCode(@ApiParam(value = "전화번호 인증확인 정보", required = true) @RequestBody VerifyCodeDTO verifyCodeDTO) throws IOException {
+		userService.verifyCode(verifyCodeDTO.phoneNumber(), verifyCodeDTO.verifyCode());
+		return SuccessNonDataResponse.success(SuccessCode.VERIFICATION_CODE_MATCH_SUCCESS);
 	}
 
 	@ApiOperation(value = "[JWT]비밀번호 확인", notes = "비밀번호 확인하기 API입니다.")

--- a/trippy-server/src/main/java/org/scoula/controller/user/dto/request/PhoneNumberDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/user/dto/request/PhoneNumberDTO.java
@@ -1,0 +1,17 @@
+package org.scoula.controller.user.dto.request;
+
+import javax.validation.constraints.Pattern;
+
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.NotBlank;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description = "인증번호 발급 요청 DTO")
+public record PhoneNumberDTO(
+	@ApiModelProperty(value = "휴대폰 번호", example = "010-1234-5678")
+	@NotBlank(message = "전화번호는 필수입니다.")
+	@Pattern(regexp = "^010-[0-9]{4}-[0-9]{4}$", message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)")
+	String phoneNumber
+) {
+}

--- a/trippy-server/src/main/java/org/scoula/controller/user/dto/request/SignUpDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/user/dto/request/SignUpDTO.java
@@ -15,7 +15,7 @@ public record SignUpDTO(
 	@ApiModelProperty(value = "주민등록번호 앞 6자리-성별코드", example = "001125-4")
 	@Pattern(regexp = "^[0-9]{6}-[1-4]$", message = "주민등록번호 형식이 올바르지 않습니다.")
 	String residentNum,
-	@ApiModelProperty(value = "휴대폰 번호", example = "010-2388-3936")
+	@ApiModelProperty(value = "휴대폰 번호", example = "010-1234-5678")
 	@NotBlank(message = "전화번호는 필수입니다.")
 	@Pattern(regexp = "^010-[0-9]{4}-[0-9]{4}$", message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)")
 	String phone,

--- a/trippy-server/src/main/java/org/scoula/controller/user/dto/request/VerifyCodeDTO.java
+++ b/trippy-server/src/main/java/org/scoula/controller/user/dto/request/VerifyCodeDTO.java
@@ -1,0 +1,19 @@
+package org.scoula.controller.user.dto.request;
+
+import javax.validation.constraints.Pattern;
+
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.NotBlank;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description = "인증번호 인증 DTO")
+public record VerifyCodeDTO(
+	@ApiModelProperty(value = "휴대폰 번호", example = "010-1234-5678")
+	@NotBlank(message = "전화번호는 필수입니다.")
+	@Pattern(regexp = "^010-[0-9]{4}-[0-9]{4}$", message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)")
+	String phoneNumber,
+	@ApiModelProperty(value = "인증코드", example = "123456")
+	String verifyCode
+) {
+}

--- a/trippy-server/src/main/java/org/scoula/domain/account/AccountVO.java
+++ b/trippy-server/src/main/java/org/scoula/domain/account/AccountVO.java
@@ -30,33 +30,34 @@ public class AccountVO extends BaseTime {
 
 	public static AccountVO from(AccountRequestDTO request, Long userId) {
 		return new AccountVO(
-				userId,
-				request.accountId(),
-				request.accountName(),
-				request.accountType(),
-				userId,
-				request.balance(),
-				request.accountCurrency(),
-				request.isDeleted()
+			userId,
+			request.accountId(),
+			request.accountName(),
+			request.accountType(),
+			userId,
+			request.balance(),
+			request.accountCurrency(),
+			request.isDeleted()
 		);
 	}
 
 	public static AccountVO fromCodefResponse(Map<String, Object> codefAccount, Long userId) {
-		String balanceStr = (String) codefAccount.get("resAccountBalance");
+
+		String balanceStr = (String)codefAccount.get("resAccountBalance");
 		Long balance = 0L;
 		if (balanceStr != null && !balanceStr.isEmpty()) {
 			balance = Long.parseLong(balanceStr);
 		}
 
 		return new AccountVO(
-				userId,
-				(String) codefAccount.get("resAccount"),
-				(String) codefAccount.get("resAccountName"),
-				AccountType.person,
-				userId,
-				balance,
-				(String) codefAccount.get("resAccountCurrency"),
-				DeletedStatus.N
+			userId,
+			(String)codefAccount.get("resAccount"),
+			(String)codefAccount.get("resAccountName"),
+			AccountType.person,
+			userId,
+			balance,
+			(String)codefAccount.get("resAccountCurrency"),
+			DeletedStatus.N
 		);
 	}
 }

--- a/trippy-server/src/main/java/org/scoula/external/sms/DiscordSmsService.java
+++ b/trippy-server/src/main/java/org/scoula/external/sms/DiscordSmsService.java
@@ -1,4 +1,0 @@
-package org.scoula.external.sms;
-
-public class DiscordSmsService {
-}

--- a/trippy-server/src/main/java/org/scoula/external/sms/DiscordSmsServiceImpl.java
+++ b/trippy-server/src/main/java/org/scoula/external/sms/DiscordSmsServiceImpl.java
@@ -1,0 +1,39 @@
+package org.scoula.external.sms;
+
+import java.util.Map;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import org.springframework.beans.factory.annotation.Value;
+
+
+@Component
+public class DiscordSmsServiceImpl implements SmsService {
+	private static final String CONTENT_PROPERTY = "content";
+
+	@Value("${discord.otp.auth-uri}")
+	private String discordWebHookUrl;
+
+	private final RestTemplate restTemplate;
+
+	public DiscordSmsServiceImpl(RestTemplate restTemplate) {
+		this.restTemplate = restTemplate;
+	}
+
+	@Override
+	public boolean sendSms(String to, String verificationCode) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+
+		Map<String, Object> body = Map.of(CONTENT_PROPERTY, verificationCode);
+
+		HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
+		ResponseEntity<String> resp = restTemplate.postForEntity(discordWebHookUrl, entity, String.class);
+		return resp.getStatusCode().is2xxSuccessful();
+	}
+}

--- a/trippy-server/src/main/java/org/scoula/external/sms/SmsService.java
+++ b/trippy-server/src/main/java/org/scoula/external/sms/SmsService.java
@@ -1,0 +1,8 @@
+package org.scoula.external.sms;
+
+import java.io.IOException;
+
+public interface SmsService {
+	boolean sendSms(String to, String verificationCode) throws IOException;
+}
+

--- a/trippy-server/src/main/java/org/scoula/service/user/UserService.java
+++ b/trippy-server/src/main/java/org/scoula/service/user/UserService.java
@@ -1,5 +1,6 @@
 package org.scoula.service.user;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -9,6 +10,8 @@ import org.scoula.common.exception.enums.ErrorCode;
 import org.scoula.common.exception.model.BadRequestException;
 import org.scoula.common.exception.model.NotFoundException;
 import org.scoula.common.exception.model.UnAuthorizedException;
+import org.scoula.common.util.SmsUtil;
+import org.scoula.common.util.VerificationCodeGenerator;
 import org.scoula.config.jwt.JwtService;
 import org.scoula.controller.user.dto.response.AllUsersTokenDTO;
 import org.scoula.controller.user.dto.request.CheckPasswordDTO;
@@ -32,6 +35,7 @@ public class UserService {
 	private final UserMapper userMapper;
 	private final JwtService jwtService;
 	private final PasswordEncoder passwordEncoder;
+	private final SmsUtil smsUtil;
 
 	/***
 	 * 회원가입
@@ -101,6 +105,37 @@ public class UserService {
 	}
 
 	/***
+	 * 전화번호 인증 코드 전송
+	 * @param phoneNumber
+	 * @throws IOException
+	 */
+	@Transactional
+	public void sendVerificationCodeMessage(final String phoneNumber) throws IOException {
+		final String verificationCode = VerificationCodeGenerator.generate();
+
+		if (!smsUtil.sendVerificationCode(phoneNumber, verificationCode))
+			throw new BadRequestException(ErrorCode.INVALID_PHONE_NUMBER_EXCEPTION);
+
+		smsUtil.saveVerificationCode(phoneNumber, verificationCode);
+	}
+
+	/***
+	 * 전화번호 인증 코드 확인
+	 * @param phoneNumber
+	 * @param verificationCode
+	 */
+	@Transactional
+	public void verifyCode(final String phoneNumber, final String verificationCode) {
+		if (!smsUtil.isVerificationCode(phoneNumber))
+			throw new NotFoundException(ErrorCode.NOT_FOUND_VERIFICATION_CODE_EXCEPTION);
+
+		if (!smsUtil.getVerificationCode(phoneNumber).equals(verificationCode))
+			throw new BadRequestException(ErrorCode.NOT_MATCH_VERIFICATION_CODE_EXCEPTION);
+
+		smsUtil.deleteVerificationCode(phoneNumber);
+	}
+
+	/***
 	 * AccessToken 갱신
 	 * [클라이언트]
 	 * 1. AccessToken이 만료되면, 해당 /user/refresh로 AccessToken 재발급 요청을 한다.
@@ -145,7 +180,7 @@ public class UserService {
 		return jwtService.generateTokenPair(userId);
 	}
 
-	public List<AllUsersTokenDTO> getAllUsersToken(){
+	public List<AllUsersTokenDTO> getAllUsersToken() {
 		List<UserVO> users = userMapper.findAll();
 
 		return users.stream()

--- a/trippy-server/src/main/resources/log4j2.xml
+++ b/trippy-server/src/main/resources/log4j2.xml
@@ -5,10 +5,6 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%t] %-5level %c{1} - %m%n"/>
         </Console>
-
-        <File name="file" fileName="logs/app.log" append="true">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%t] %-5level %c{1} - %m%n"/>
-        </File>
     </Appenders>
 
     <Loggers>


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #11 

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
1h/2h

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
1. 문자 인증코드 랜덤으로 잘 오고 있고
<img width="643" height="104" alt="스크린샷 2025-08-13 오전 12 26 07" src="https://github.com/user-attachments/assets/15e6fec0-ad34-4b43-9358-ed83024bf304" />

2. 전화번호와 인증 코드 일치하는 값인지 확인
<img width="1268" height="297" alt="스크린샷 2025-08-13 오전 12 21 11" src="https://github.com/user-attachments/assets/06381fb5-44eb-447d-9a98-5ecb9d1f6b9e" />

3. 존재하지 않는 인증코드 에러 로깅도 잘 되고 있습니다
<img width="1272" height="292" alt="스크린샷 2025-08-13 오전 12 21 29" src="https://github.com/user-attachments/assets/3dc27eb2-a1c7-4b70-9ca7-c62d518175da" />

<img width="634" height="156" alt="스크린샷 2025-08-13 오전 12 21 56" src="https://github.com/user-attachments/assets/836105eb-041b-40e4-9078-adfe3888cac2" />


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
# 📩 인증번호 발송 및 검증 로직

이 PR에서는 **인증번호(OTP) 발송 → Redis 저장 → 검증 → 삭제**의 전체 흐름을 구현하였습니다.  
발송 채널은 `SmsService` 인터페이스를 통해 추상화하였으며, 현재 구현체는 **Discord Webhook**을 사용합니다.

---

## 🔄 동작 흐름

1. **인증번호 생성**
   - 6자리 난수를 생성 (서비스 레이어에서 처리)
   - 예: `482913`

2. **Discord Webhook을 통한 발송**
   - `SmsService` 인터페이스의 구현체 `DiscordSmsServiceImpl` 사용.
   - Webhook URL로 `POST` 요청을 보내 Discord 채널에 인증번호 전송.
   - 메시지 포맷:  
     ```
     [482913] trippy에서 보낸 인증번호입니다.
     ```

3. **Redis 저장**
   - 발송된 인증번호를 `RedisTemplate<String, String>`으로 저장.
   - **Key**: 수신자 전화번호  
     **Value**: 인증번호 문자열  
     **TTL**: 3분 (`TimeUnit.MINUTES`)
   - Redis의 TTL 기능으로 3분 후 자동 삭제 (만료).

4. **인증번호 검증**
   - 사용자 입력값과 Redis에 저장된 값을 비교.
   - 일치 시: Redis 키 즉시 삭제 → 검증 성공 (HTTP 200)
   - 불일치 시: 에러 메시지 반환 (예: `인증번호가 올바르지 않거나 만료되었습니다.`)

5. **TTL 기반 자동 만료**
   - Redis가 TTL이 지난 키를 자동 제거하므로, 별도 배치/스케줄러 불필요.
   - 검증 전에 TTL이 끝나면 `null` 반환 → 만료 처리.

---

## 📂 주요 클래스 역할

### `SmsUtil`
인증번호 발송과 Redis 저장/검증/삭제를 담당하는 유틸리티.

- `sendVerificationCode(to, code)`  
  발송 채널(SmsService)을 통해 인증번호 전송.
- `saveVerificationCode(to, code)`  
  Redis에 코드 저장, TTL = 3분.
- `isVerificationCode(to)`  
  해당 번호에 코드가 존재하는지 여부 반환.
- `getVerificationCode(to)`  
  Redis에서 현재 저장된 코드 값 조회.
- `deleteVerificationCode(to)`  
  코드 검증 성공 시 Redis 키 즉시 삭제.

### `SmsService`
발송 채널 추상화 인터페이스.

### `DiscordSmsServiceImpl`
`SmsService` 구현체로, **Discord Webhook**을 사용하여 인증번호 전송.

- Webhook URL은 환경변수(`discord.otp.auth-uri`)에서 주입.
- `RestTemplate`을 통한 `POST` 요청으로 Discord 메시지 발송.

---

## ⚙️ 기술적 포인트
- **채널 추상화**  
  `SmsService` 인터페이스로 발송 채널을 유연하게 교체 가능 (Discord, SMS, 이메일 등).
 
- **TTL 기반 보안성**  
  Redis의 만료 기능을 사용하여 3분 후 자동 삭제, 별도 스케줄러 불필요.
  
- **O(1) 성능**  
  Redis의 Key-Value 조회/저장/삭제는 O(1) 연산.
  
- **운영 안전성**  
  인증번호는 서버 메모리에 저장하지 않고 Redis에만 저장 → 메모리 누수 방지.