### PR TITLE
[FEAT] 카테고리 배치로, gpt 태깅 

### DIFF
--- a/trippy-server/build.gradle
+++ b/trippy-server/build.gradle
@@ -137,7 +137,16 @@ dependencies {
 
     implementation 'com.google.zxing:core:3.5.3'
     implementation 'com.google.zxing:javase:3.5.3'
+
+    // Gson
+    implementation 'com.google.code.gson:gson:2.11.0'
+
+    //chatGPT
+//    implementation 'com.openai:openai-java:3.0.3'
+    implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.4'
+
 }
+
 
 
 test {

--- a/trippy-server/src/main/java/org/scoula/config/scheduler/SchedulerConfig.java
+++ b/trippy-server/src/main/java/org/scoula/config/scheduler/SchedulerConfig.java
@@ -1,0 +1,8 @@
+package org.scoula.config.scheduler;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig { }

--- a/trippy-server/src/main/java/org/scoula/external/chatGPT/GPTService.java
+++ b/trippy-server/src/main/java/org/scoula/external/chatGPT/GPTService.java
@@ -1,0 +1,156 @@
+// org.scoula.external.chatGPT.GPTService
+package org.scoula.external.chatGPT;
+
+import com.google.gson.*;
+
+import lombok.RequiredArgsConstructor;
+import okhttp3.*;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class GPTService {
+
+	private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+	private static final String MODEL = "gpt-4o-mini"; // 저렴 & 충분
+
+	@Value("${openai.api.key}")
+	private String apiKey;
+
+	@Value("${openai.api.base:https://api.openai.com/v1}")
+	private String apiBase;
+
+	private final OkHttpClient http = new OkHttpClient.Builder().callTimeout(25, TimeUnit.SECONDS).build();
+
+	/**
+	 * title만으로 고정 카테고리 분류.
+	 * 실패/이상응답 시 "OTHER" 반환.
+	 */
+	public String suggestCategory(String title) {
+		String system = """
+			You are a strict text classifier.
+			- Task: Assign one category for a given transaction title.
+			- Categories:
+			  * FOOD: 음식, 카페, 식당, 음료, 레스토랑
+			  * TRANSPORT: 택시, 버스, 지하철, 항공, Uber, 교통
+			  * SHOPPING: 마트, 편의점, 쇼핑몰, 상점
+			  * ACCOMMODATION: 호텔, 숙박, 에어비앤비
+			  * ACTIVITY: 관광, 티켓, 액티비티, 공연, 체험
+			  * OTHER: 위에 속하지 않거나 애매하면 반드시 OTHER
+			- Rules:
+			  * Use ONLY one of [FOOD, TRANSPORT, SHOPPING, ACCOMMODATION, ACTIVITY, OTHER].
+			  * Output MUST be JSON only. No explanation. No extra text.
+			  * If unclear → return {"category":"OTHER"}.
+			  Examples:
+			  "스타벅스 아이스 아메리카노" → {"category":"FOOD"}
+			  "우버 라과디아 → 맨해튼" → {"category":"TRANSPORT"}
+			  "7-Eleven 결제" → {"category":"SHOPPING"}
+			  "신라호텔 1박" → {"category":"ACCOMMODATION"}
+			  "박물관 입장권" → {"category":"ACTIVITY"}
+			  "테스트 결제 123" → {"category":"OTHER"}
+			""";
+
+		String user = String.format("""
+			Classify the following transaction:
+			
+			title: "%s"
+			
+			Return ONLY in JSON form:
+			{"category":"<ONE_OF [FOOD|TRANSPORT|SHOPPING|ACCOMMODATION|ACTIVITY|OTHER]"}
+			""", title);
+
+		// Structured Outputs 유사하게 강제: function-like JSON schema
+		JsonObject schema = new JsonObject();
+		schema.addProperty("type", "object");
+		JsonObject props = new JsonObject();
+		JsonObject category = new JsonObject();
+		category.addProperty("type", "string");
+		JsonArray enums = new JsonArray();
+		for (String v : new String[] {"FOOD", "TRANSPORT", "SHOPPING", "ACCOMMODATION", "ACTIVITY", "OTHER"}) {
+			enums.add(v);
+		}
+		category.add("enum", enums);
+		props.add("category", category);
+		schema.add("properties", props);
+		JsonArray required = new JsonArray();
+		required.add("category");
+		schema.add("required", required);
+
+		JsonObject responseFormat = new JsonObject();
+		responseFormat.addProperty("type", "json_schema");
+		responseFormat.addProperty("name", "TxCategory");
+		responseFormat.add("json_schema", schema);
+
+		JsonObject body = new JsonObject();
+		body.addProperty("model", MODEL);
+		JsonArray input = new JsonArray();
+		JsonObject msgSystem = new JsonObject();
+		msgSystem.addProperty("role", "system");
+		msgSystem.addProperty("content", system);
+		JsonObject msgUser = new JsonObject();
+		msgUser.addProperty("role", "user");
+		msgUser.addProperty("content", user);
+		input.add(msgSystem);
+		input.add(msgUser);
+		body.add("input", input);
+		body.add("response_format", responseFormat);
+
+		Request request = new Request.Builder().url(apiBase + "/responses")
+			.addHeader("Authorization", "Bearer " + apiKey)
+			.post(RequestBody.create(body.toString(), JSON))
+			.build();
+
+		try (Response resp = http.newCall(request).execute()) {
+			if (!resp.isSuccessful() || resp.body() == null)
+				return "OTHER";
+			String s = resp.body().string();
+			// Responses API: output[0].content[0].text 또는 structured JSON
+			JsonObject root = JsonParser.parseString(s).getAsJsonObject();
+			String outText = extractText(root);
+			if (outText == null || outText.isBlank())
+				return "OTHER";
+			// JSON 파싱 시도
+			try {
+				JsonObject jobj = JsonParser.parseString(outText.trim()).getAsJsonObject();
+				String cat = jobj.get("category").getAsString().toUpperCase();
+				return normalize(cat);
+			} catch (Exception ignore) {
+				// 만약 평문이면 안전 필터
+				return normalize(outText.trim().toUpperCase());
+			}
+		} catch (IOException e) {
+			return "OTHER";
+		}
+	}
+
+	private static String extractText(JsonObject root) {
+		// Responses API 표준 필드: output_text가 있으면 우선
+		if (root.has("output_text"))
+			return root.get("output_text").getAsString();
+		// fallback: output -> [ { content: [ { type:"output_text", text:"..." } ] } ]
+		try {
+			JsonArray out = root.getAsJsonArray("output");
+			JsonObject first = out.get(0).getAsJsonObject();
+			JsonArray content = first.getAsJsonArray("content");
+			for (var el : content) {
+				JsonObject c = el.getAsJsonObject();
+				if (c.has("text"))
+					return c.get("text").getAsString();
+			}
+		} catch (Exception ignore) {
+		}
+		return null;
+	}
+
+	private static String normalize(String x) {
+		return switch (x) {
+			case "FOOD", "TRANSPORT", "SHOPPING", "ACCOMMODATION", "ACTIVITY", "OTHER" -> x;
+			default -> "OTHER";
+		};
+	}
+}

--- a/trippy-server/src/main/java/org/scoula/mapper/transaction/TransactionMapper.java
+++ b/trippy-server/src/main/java/org/scoula/mapper/transaction/TransactionMapper.java
@@ -22,4 +22,8 @@ public interface TransactionMapper {
 		@Param("endDate") LocalDateTime endDate);
 
 	TransactionVO findByTransactionId(Long transactionId);
+
+	List<TransactionVO> findUncategorized(@Param("limit") int limit);
+	int updateCategoryById(@Param("transactionId") Long transactionId,
+		@Param("category") String category);
 }

--- a/trippy-server/src/main/java/org/scoula/service/transaction/TransactionCategoryBatch.java
+++ b/trippy-server/src/main/java/org/scoula/service/transaction/TransactionCategoryBatch.java
@@ -1,0 +1,22 @@
+package org.scoula.service.transaction;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class TransactionCategoryBatch {
+
+	private final TransactionService transactionService;
+
+	// 앱 시작 10초 후부터 60초 간격
+	// @Scheduled(initialDelay = 10_000L, fixedDelay = 60_000L)
+	public void fillMissingCategories() {
+		int updated = transactionService.classifyAndSaveMissingCategories(100); // 1회 최대 100건
+		log.info("Category batch updated {} rows", updated);
+	}
+}

--- a/trippy-server/src/main/java/org/scoula/service/transaction/TransactionService.java
+++ b/trippy-server/src/main/java/org/scoula/service/transaction/TransactionService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.scoula.domain.transaction.TransactionVO;
+import org.scoula.external.chatGPT.GPTService;
 import org.scoula.mapper.transaction.TransactionMapper;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +17,22 @@ import lombok.extern.log4j.Log4j2;
 public class TransactionService {
 
 	private final TransactionMapper transactionMapper;
+	private final GPTService gptService;
+
+	public int classifyAndSaveMissingCategories(int limit) {
+		int updated = 0;
+		var targets = transactionMapper.findUncategorized(limit);
+		for (var t : targets) {
+			String title = t.getTitle();
+			if (title == null || title.isBlank()) {
+				updated += transactionMapper.updateCategoryById(t.getTransactionId(), "OTHER");
+				continue;
+			}
+			String cat = gptService.suggestCategory(title);
+			updated += transactionMapper.updateCategoryById(t.getTransactionId(), cat);
+		}
+		return updated;
+	}
 
 	public List<TransactionVO> getUserExpenseTransactions(Long userId, String accountId, LocalDateTime startDate,
 		LocalDateTime endDate) {
@@ -25,4 +42,6 @@ public class TransactionService {
 	public TransactionVO getTransaction(Long transactionId) {
 		return transactionMapper.findByTransactionId(transactionId);
 	}
+
+
 }

--- a/trippy-server/src/main/resources/org/scoula/mapper/transaction/TransactionMapper.xml
+++ b/trippy-server/src/main/resources/org/scoula/mapper/transaction/TransactionMapper.xml
@@ -92,4 +92,32 @@
         WHERE transaction_id = #{transactionId}
     </select>
 
+    <select id="findUncategorized" resultMap="transactionMap">
+        SELECT
+        transaction_id,
+        account_id,
+        user_id,
+        transaction_type,
+        amount,
+        title,
+        NULLIF(TRIM(category), '') AS category,  <!-- ✅ 빈 문자열 -> NULL -->
+        latitude,
+        longitude,
+        balance_after,
+        status,
+        currency_code,
+        created_at,
+        updated_at
+        FROM transaction
+        WHERE (category IS NULL OR TRIM(category) = '')
+        ORDER BY created_at DESC
+        LIMIT #{limit}
+    </select>
+
+    <update id="updateCategoryById">
+        UPDATE transaction
+        SET category = UPPER(#{category}), updated_at = NOW()
+        WHERE transaction_id = #{transactionId}
+    </update>
+
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈번호
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number(이곳에 이슈 번호 작성)를 적어주세요 -->
* Closed #100 

## 📌 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
<!-- ISSUE에 작성한 시간 대비 실제 작업시간을 적어가며, 객관적인 개발 예상시간을 그려보는 눈을 길러 봅시다. -->
2h

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요. 변경 사항 및 이유 작성 -->
GPT secret key를 발급 후에, transaction category가 비어 있는 항목을 기준으로 조회후에, 태깅 해주는 api를 만들었습니다.
다만 유저호출형 api가 아니기에 배치로 할 수 있도록 설정을 해놨고, 
배포 본에는 배치 시간은 주석 처리했습니다.

가격적인 부분으로 인해 limit은 100으로 설정했고, update 하는 부분에서 단건과 100건 batch 하는 것을 고민하고 있다가, 실패 로직으로 api 홑출하는 것이 가격적인 부분에서 더 이점이 적다 생각했습니더ㅏ...

가격이 많이 드는 api를 어떻게 잘 호출할 수 있을지 고민을 더 해봐야할것 같습니다. 

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
